### PR TITLE
feat: add ai-rules (v0.5.0) with claude code + copilot stubs

### DIFF
--- a/.github/agents/implementer.md
+++ b/.github/agents/implementer.md
@@ -1,0 +1,1 @@
+../../agents/implementer.md

--- a/.github/agents/planner.md
+++ b/.github/agents/planner.md
@@ -1,0 +1,1 @@
+../../agents/planner.md

--- a/.github/agents/python-sec31.md
+++ b/.github/agents/python-sec31.md
@@ -1,0 +1,1 @@
+../../agents/python-sec31.md

--- a/.github/agents/reviewer.md
+++ b/.github/agents/reviewer.md
@@ -1,0 +1,1 @@
+../../agents/reviewer.md

--- a/.github/agents/validator.md
+++ b/.github/agents/validator.md
@@ -1,0 +1,1 @@
+../../agents/validator.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,7 @@
+<!-- ai-rules-reference -->
+## AI Development Rules
+
+Follow the AI development rules defined in `.ai-rules/AGENTS.md` and all
+referenced rule files in `.ai-rules/rules/` before beginning any feature work.
+
+<!-- Project-specific Copilot instructions below this line -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Skip if the push was made by the bot itself (e.g., the .version bump commit)
+    # to prevent an infinite release loop.
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine version bump
+        id: version
+        run: |
+          # Get the latest tag, or default to v0.0.0
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "latest_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
+
+          # Parse current version
+          VERSION="${LATEST_TAG#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          # Determine bump from commit messages since last tag
+          if [[ "$LATEST_TAG" == "v0.0.0" ]]; then
+            COMMITS=$(git log --oneline)
+          else
+            COMMITS=$(git log "${LATEST_TAG}..HEAD" --oneline)
+          fi
+
+          # If there are no new commits since the last tag, skip the release.
+          if [[ -z "$COMMITS" ]]; then
+            echo "No new commits since ${LATEST_TAG} — nothing to release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if echo "$COMMITS" | grep -qiE '(BREAKING|major:)'; then
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            PATCH=0
+          elif echo "$COMMITS" | grep -qiE '(feat:|minor:)'; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          else
+            PATCH=$((PATCH + 1))
+          fi
+
+          NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "new_tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Bumping ${LATEST_TAG} → ${NEW_TAG}"
+
+      - name: Update .version file
+        if: steps.version.outputs.skip != 'true'
+        run: |
+          cat > .version <<EOF
+          origin=https://github.com/${{ github.repository }}
+          tag=${{ steps.version.outputs.new_tag }}
+          EOF
+          # Clean up leading whitespace from heredoc
+          sed -i 's/^[[:space:]]*//' .version
+
+      - name: Commit version bump
+        if: steps.version.outputs.skip != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add .version
+          if git diff --cached --quiet; then
+            echo "No changes to .version — skipping commit"
+          else
+            git commit -m "chore: bump version to ${{ steps.version.outputs.new_tag }}"
+            git push
+          fi
+
+      - name: Create tag
+        if: steps.version.outputs.skip != 'true'
+        run: |
+          NEW_TAG="${{ steps.version.outputs.new_tag }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${NEW_TAG}" &>/dev/null; then
+            echo "Tag ${NEW_TAG} already exists on remote — skipping tag creation."
+          else
+            git tag "$NEW_TAG"
+            git push origin "$NEW_TAG"
+          fi
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_TAG="${{ steps.version.outputs.new_tag }}"
+          if gh release view "$NEW_TAG" &>/dev/null; then
+            echo "Release ${NEW_TAG} already exists — skipping release creation."
+          else
+            gh release create "$NEW_TAG" \
+              --title "$NEW_TAG" \
+              --generate-notes
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# Editors
+*.swp
+*.swo
+*~
+.vscode/
+.idea/
+
+# Task artifacts (these are project-specific, not part of the rules repo)
+tasks/

--- a/.version
+++ b/.version
@@ -1,0 +1,2 @@
+origin=https://github.com/JonathanPorta/ai-rules
+tag=v0.5.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# AI Development Rules
+
+These rules govern how AI agents approach feature development in this project.
+They are **mandatory** — not suggestions.
+
+Read and internalize ALL rules before beginning any feature work.
+
+## Required Rules
+
+These rules are mandatory for all feature work. Read all of them before starting.
+
+0. [Project Planning](rules/00-project-planning.md) — Phased planning for multi-feature projects
+1. [Workflow Overview](rules/01-workflow-overview.md) — The end-to-end process
+2. [PRD Generation](rules/02-prd.md) — How to produce a Product Requirements Document
+3. [Task Generation](rules/03-task-generation.md) — How to decompose a PRD into tasks
+4. [Validation-First Development](rules/04-validation-first.md) — Writing validation before code
+5. [Task Execution](rules/05-task-execution.md) — How to implement and verify tasks
+6. [Session State](rules/06-session-state.md) — Persisting context across sessions
+7. [Command Surface](rules/07-command-surface.md) — Use Makefile as the canonical command surface
+
+## Domain Rule Sets
+
+These rules are required **when the work includes user-facing UX, UI, flows,
+IA, screen specs, design systems, or design critique**.
+
+<!-- Rule numbering: 00–07 core (required), 08 optional, 09–29 reserved,
+     30–38 design domain. -->
+
+
+30. [Design Principles](rules/design/30-design-principles.md) — What makes a product feel coherent, trustworthy, and polished
+31. [UX Brief and Intent](rules/design/31-ux-brief-and-intent.md) — Define the user, job, emotional goal, and success criteria
+32. [Information Architecture](rules/design/32-information-architecture.md) — Organize navigation and content so it stays legible under growth
+33. [User Journeys and State Inventory](rules/design/33-user-journeys-and-state-inventory.md) — Enumerate flows and states before polishing screens
+34. [Trust, Feedback, and Confirmation](rules/design/34-trust-feedback-and-confirmation.md) — Make system status visible and risky actions proportionate
+35. [Visual System and Hierarchy](rules/design/35-visual-system-and-hierarchy.md) — Create emphasis, rhythm, and visual coherence
+36. [Screen Review and Critique](rules/design/36-screen-review-and-critique.md) — Evaluate screens with concrete review questions
+37. [Accessibility and Legibility](rules/design/37-accessibility-and-legibility.md) — Ensure the interface is usable, readable, and robust
+38. [Design Memory and Consistency](rules/design/38-design-memory-and-consistency.md) — Preserve recurring patterns and decisions over time
+
+## Optional Rules (disabled by default)
+
+These rules are only active when explicitly enabled below. To enable, move a rule
+from the "available" list to the "enabled" list.
+
+**Available:**
+- [TDD Enforcement](rules/08-tdd-enforcement.md) — Red-then-green evidence requirement
+
+**Enabled:**
+<!-- Move rules here to activate them. Example: -->
+<!-- - [TDD Enforcement](rules/08-tdd-enforcement.md) -->
+
+## Core Principles
+
+1. **Understand before you propose.** Before writing a PRD or suggesting changes,
+   explore the codebase and produce a written analysis. Document what you found,
+   what patterns exist, and what constraints you discovered. The human reviews this
+   analysis BEFORE you propose solutions. Every misunderstanding caught here saves
+   hours downstream.
+
+2. **Nothing ships without acceptance criteria.** Every feature has human-approved
+   acceptance criteria before any code is written.
+
+3. **Validation before implementation.** For every task, define how you will prove
+   it works BEFORE writing the code.
+
+4. **Observable proof over self-assessment.** "It works" is not validation. Show a
+   test passing, a command output, or a verifiable state change.
+
+5. **Human owns acceptance, AI owns validation.** The human defines what "done"
+   means. The AI defines how to prove each step got there.
+
+6. **Fail loudly.** If validation fails, stop. Do not mark the task complete. Do
+   not proceed to the next task. Report what failed and why.
+
+7. **Scope is sacred.** Do not add, remove, or modify acceptance criteria without
+   human approval. If you discover unplanned work, surface it — don't silently do it.
+
+8. **Plan scales to scope.** Single feature? Go straight to PRD. Multi-feature
+   project? Start with a phased project plan. Don't force heavyweight process on
+   simple work, and don't skip planning on complex work.
+
+9. **Preserve what you learn.** Maintain a session state file so that context
+   loss — from compaction, session end, or conversation switch — does not mean
+   knowledge loss. Decisions made by the human are especially expensive to lose.
+
+10. **Design the state machine, not just the hero screen.** For user-facing work,
+    spend effort on orientation, trust, progress visibility, edge states, and
+    confirmation moments — not only on a polished happy path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+<!-- ai-rules-reference -->
+@.ai-rules/AGENTS.md
+
+<!-- Project-specific Claude Code instructions below this line -->

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 portaj
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,328 @@
+# ai-rules
+
+Structured rules for AI-assisted development. Forces codebase understanding,
+acceptance criteria, validation-before-implementation, and human gates at
+critical decision points. Includes a first-class design domain for user-facing
+UX/UI work.
+
+## The Problem
+
+AI coding agents will happily generate code without understanding the codebase,
+skip validation, and mark their own work complete. This leads to features that
+compile but don't work, tasks that are checked off but not verified, and scope
+that silently drifts.
+
+For user-facing work, the failure mode is different but just as expensive:
+agents optimize for a pretty hero screen, skip state design, ignore trust and
+error handling, and produce screens that look polished but fall apart in real use.
+
+## The Solution
+
+A set of mandatory rules that enforce:
+
+1. **Codebase analysis before proposals** — AI must document its understanding and get human confirmation
+2. **Human-approved acceptance criteria** before any code is written
+3. **AI-generated validation steps** before each task is implemented
+4. **Observable proof** of task completion (not self-assessment)
+5. **Human gates** at critical decision points
+6. **Phased project planning** for multi-feature initiatives
+7. **Session state persistence** so context loss doesn't mean knowledge loss
+8. **Design workflow discipline** for user-facing UX/UI work: intent, journeys, states, trust, hierarchy, and critique
+
+## Design Domain
+
+The design rules are for work involving:
+- product UX
+- screen and flow design
+- information architecture
+- design systems
+- AI-generated interface concepts
+- critique of existing products
+
+They are not a replacement for engineering rules. They are a companion domain
+that keeps AI from generating glossy nonsense with no operational backbone.
+
+Start with:
+- [Design Principles](rules/design/30-design-principles.md)
+- [UX Brief and Intent](rules/design/31-ux-brief-and-intent.md)
+- [User Journeys and State Inventory](rules/design/33-user-journeys-and-state-inventory.md)
+- [Screen Review and Critique](rules/design/36-screen-review-and-critique.md)
+
+## Install
+
+### One-liner (recommended)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/JonathanPorta/ai-rules/main/install.sh | bash
+```
+
+This will:
+- **Fresh install:** `git subtree add` the latest release to `.ai-rules/`
+- **Update:** `git subtree pull` to the latest release if already installed
+- **Abort:** warn and exit if `.ai-rules/` exists but wasn't installed by this script
+
+### Manual: Git Subtree
+
+```bash
+# Add as a subtree (pin to a release tag)
+git subtree add --prefix=.ai-rules https://github.com/JonathanPorta/ai-rules.git v1.0.0 --squash
+
+# Update later
+git subtree pull --prefix=.ai-rules https://github.com/JonathanPorta/ai-rules.git v1.2.0 --squash
+```
+
+### Manual: Git Submodule
+
+```bash
+git submodule add https://github.com/JonathanPorta/ai-rules.git .ai-rules
+```
+
+### Manual: Just copy it
+
+```bash
+cp -r ai-rules/ /path/to/your/project/.ai-rules/
+```
+
+## Platform Setup
+
+After installing, generate platform-specific config stubs:
+
+```bash
+# Wire up for specific platforms
+.ai-rules/setup.sh --platforms cursor,windsurf,copilot
+
+# Wire up for all supported platforms
+.ai-rules/setup.sh --platforms all
+
+# See what's supported
+.ai-rules/setup.sh --list
+```
+
+The setup script creates thin stub files at each platform's canonical config
+location. These stubs reference `.ai-rules/AGENTS.md` and leave room for
+project-specific additions.
+
+### Platform Details
+
+| Platform | Config Location | Format |
+|----------|----------------|--------|
+| Claude Code | `CLAUDE.md` (root) | Plain markdown; uses `@.ai-rules/AGENTS.md` import |
+| Cursor | `.cursor/rules/ai-rules.mdc` | MDC with `alwaysApply: true` frontmatter |
+| Windsurf | `.windsurf/rules/ai-rules.md` | Markdown with `trigger: always_on` frontmatter |
+| GitHub Copilot | `.github/copilot-instructions.md` | Plain markdown |
+| Amp | `AGENTS.md` (root) | Plain markdown; Amp walks parent dirs |
+
+Stub bodies live in `templates/platform-stubs/`. To add a platform, edit
+`PLATFORMS_TABLE` in `setup.sh` and drop a matching template file there.
+
+## Role-Based Agents
+
+The `agents/` directory contains four complementary agent definitions that
+mirror the workflow's human gates. Each role has scoped tool access to
+enforce separation of planning, validation, implementation, and review.
+
+| Agent | Tools | Purpose |
+|-------|-------|---------|
+| [planner](agents/planner.md) | read, search | Explores the codebase, produces analysis, and generates PRDs with acceptance criteria. Does not write code. |
+| [implementer](agents/implementer.md) | read, search, edit, execute | Decomposes approved PRDs into tasks and implements them using validation-first development. |
+| [validator](agents/validator.md) | read, search, edit, execute | Writes validation plans and test cases before implementation, then executes them to verify task completion. |
+| [reviewer](agents/reviewer.md) | read, search, execute | Reviews completed work against acceptance criteria and produces verification evidence tables. |
+
+These files are instruction prompts, not platform-native agent definitions.
+Adapt them to your agent runner of choice — for example, GitHub Copilot's
+custom agents feature requires `*.agent.md` files with specific YAML
+frontmatter (prompt, tools, MCP servers), which is a per-project wrapping
+step beyond what `setup.sh` generates.
+
+These agents divide the ai-rules workflow into distinct roles with appropriate
+tool access:
+
+- **planner** handles Phases 1–2 (PRD and task generation). Limited to read-only
+  tools to enforce human gates before any code is written.
+- **validator** handles the validation-first discipline from Phase 3. Writes
+  validation plans, creates failing tests (red phase), and runs all validation
+  checks after implementation (green phase). Can write test files but not
+  implementation code.
+- **implementer** handles Phase 3 implementation. Takes the validator's failing
+  tests and validation plan as a contract, then writes the code to make them pass.
+- **reviewer** handles Phase 4 (feature verification). Has execute access to
+  run tests independently but cannot modify code — enforcing separation between
+  implementation and review.
+
+## Structure
+
+```text
+.ai-rules/
+  .version                         # Origin and version tracking
+  AGENTS.md                        # Entry point and core principles
+  setup.sh                         # Platform stub generator
+  install.sh                       # curl|bash installer
+  docs/
+    overview.md                    # Why the framework exists and what it covers
+    how-to-use.md                  # Recommended workflow by task type
+    rule-loading-order.md          # How AI should discover and apply rules
+    examples/
+      design-example.md            # Example of the design rules in practice
+  rules/
+    00-project-planning.md         # Phased planning for multi-feature projects
+    01-workflow-overview.md        # End-to-end process with human gates
+    02-prd.md                      # Codebase analysis, PRD generation, acceptance criteria
+    03-task-generation.md          # Task decomposition with validation criteria
+    04-validation-first.md         # Write validation before implementation
+    05-task-execution.md           # Execute tasks, track progress, verify completion
+    06-session-state.md            # Persist context across sessions
+    07-command-surface.md          # Required command and tool invocation boundaries
+    08-tdd-enforcement.md          # (Optional) Red-then-green TDD evidence
+    design/
+      30-design-principles.md      # Design principles for coherent user-facing work
+      31-ux-brief-and-intent.md    # User, job, emotional goal, constraints, success
+      32-information-architecture.md
+      33-user-journeys-and-state-inventory.md
+      34-trust-feedback-and-confirmation.md
+      35-visual-system-and-hierarchy.md
+      36-screen-review-and-critique.md
+      37-accessibility-and-legibility.md
+      38-design-memory-and-consistency.md
+  agents/
+    planner.md                     # PRD and project planning agent
+    validator.md                   # Validation plan and test-first agent
+    implementer.md                 # Validation-first task implementation agent
+    reviewer.md                    # Feature verification and AC review agent
+  scripts/
+    tdd-check.sh                   # (Optional) Git timestamp TDD verifier
+  templates/
+    project-plan.md                # Blank project plan template
+    prd.md                         # Blank PRD template
+    tasks.md                       # Blank task list template
+    session-state.md               # Blank session state template
+    design/
+      ux-brief-template.md         # Blank UX brief
+      state-inventory-template.md  # Flow and state inventory
+      screen-spec-template.md      # Single-screen specification
+      design-review-checklist.md   # Structured critique checklist
+      visual-audit-template.md     # Audit an existing product or screen set
+    platform-stubs/
+      claude.md                    # CLAUDE.md stub with @.ai-rules/AGENTS.md import
+      cursor.mdc                   # Cursor MDC stub (alwaysApply: true)
+      windsurf.md                  # Windsurf stub (trigger: always_on)
+      copilot.md                   # .github/copilot-instructions.md stub
+      amp.md                       # Root AGENTS.md stub for Amp
+  examples/
+    sample-ux-brief.md             # Filled UX brief example
+    sample-state-inventory.md      # Filled state inventory example
+    sample-design-review.md        # Filled design critique example
+```
+
+## How It Works
+
+### Single Feature Workflow
+
+```text
+Feature Request
+  → Codebase Analysis (AI writes, human reviews)     ← GATE
+  → PRD with Acceptance Criteria (human approves)    ← GATE
+  → Task Decomposition (human confirms parent tasks) ← GATE
+  → For each task:
+      → Validation plan (AI writes before coding)
+      → Implementation
+      → Validation execution (pass/fail reported)
+  → Feature Verification (human confirms ACs met)    ← GATE
+```
+
+### Multi-Feature Project Workflow
+
+```text
+Project Vision
+  → Project Brief (human approves)                   ← GATE
+  → Phased Plan with Dependencies (human approves)  ← GATE
+  → Phase PRDs (human approves each)                ← GATE
+  → Phase Task Lists (human confirms parent tasks)  ← GATE
+  → Implementation + Validation per task
+  → Phase Verification                               ← GATE
+  → Next Phase
+```
+
+### Design Workflow
+
+```text
+Design Request
+  → UX Brief (user, job, emotional goal, constraints)
+  → IA + Journey Mapping
+  → State Inventory
+  → Screen Specs / Concept Direction
+  → Trust + Feedback Review
+  → Accessibility + Legibility Review
+  → Design Critique with explicit tradeoffs
+```
+
+The core rule for design work is simple: **do not polish a screen before you
+understand the flow and state model that screen belongs to.**
+
+## Suggested Entry Points
+
+| Work Type | Start Here |
+|-----------|------------|
+| Single feature implementation | `rules/02-prd.md` |
+| Multi-feature initiative | `rules/00-project-planning.md` |
+| User-facing product or UX work | `rules/design/31-ux-brief-and-intent.md` |
+| Critique of an existing app or screen set | `templates/design/visual-audit-template.md` |
+| Structured design review | `rules/design/36-screen-review-and-critique.md` |
+
+## Documentation
+
+- [Overview](docs/overview.md)
+- [How to Use](docs/how-to-use.md)
+- [Rule Loading Order](docs/rule-loading-order.md)
+- [Design Example](docs/examples/design-example.md)
+
+## The Three Types of Criteria
+
+| | Acceptance Criteria | Validation Criteria | Exit Criteria |
+|---|---|---|---|
+| **Owner** | Human | AI | Human + AI |
+| **Scope** | Feature-level | Task-level | Phase-level |
+| **When defined** | PRD phase | Pre-implementation | Project planning |
+| **What it answers** | "What does done mean?" | "How do we prove this task got us there?" | "What must be true to move to the next phase?" |
+| **Approval** | Required before any work | Human reviews if desired | Required before next phase |
+| **Mutability** | Only with human approval | AI refines as needed | Only with human approval |
+
+## Optional Rules
+
+Some rules are opt-in. They live in the repo but are disabled by default.
+To enable an optional rule, edit `AGENTS.md` and move it from the "Available"
+list to the "Enabled" list under the Optional Rules section.
+
+| Rule | What It Does | Enable When |
+|------|-------------|-------------|
+| [TDD Enforcement](rules/08-tdd-enforcement.md) | Requires red-then-green test evidence | Your team practices TDD and has test infrastructure |
+
+Optional rules also come with supporting tooling in `scripts/`:
+- `tdd-check.sh` — compares git timestamps to verify test-before-implementation ordering
+
+## Extending for Your Organization
+
+These rules are intentionally generic. Fork this repo to add:
+
+- Organization-specific coding standards
+- CI/CD pipeline validation steps
+- Project management tool integration (Jira, Linear, etc.)
+- Security and compliance checks
+- Infrastructure-specific validation patterns
+- Product design system conventions and review requirements
+
+Keep extensions in a separate file or subtree of files and reference them from
+your fork's `AGENTS.md`.
+
+## Versioning
+
+Releases are cut automatically on merge to `main`:
+- `BREAKING` or `major:` in commit message → major bump
+- `feat:` or `minor:` → minor bump
+- Everything else → patch bump
+
+The `.version` file tracks the installed version and origin, used by the
+installer to detect updates.
+
+## License
+
+Apache-2.0

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -1,0 +1,83 @@
+---
+name: implementer
+description: Decomposes approved PRDs into tasks and implements them using validation-first development.
+tools: ["read", "search", "edit", "execute"]
+---
+
+You are an implementation specialist that follows the ai-rules framework. You
+take approved PRDs and turn them into working code using validation-first
+development. You never start coding without an approved PRD and task list.
+
+## Your Workflow
+
+### Phase 1: Task Generation (rules/03-task-generation.md)
+
+1. **Read the approved PRD** and its acceptance criteria.
+2. **Explore the codebase** to identify relevant files, patterns, and test
+   infrastructure. List actual file paths — do not guess.
+3. **Generate parent tasks** with AC traceability. Present them to the human:
+   > "I have generated the high-level tasks based on your approved PRD. Please
+   > review the breakdown and AC mapping. Respond with 'Go' to proceed to
+   > detailed sub-tasks, or suggest changes."
+4. **Wait for confirmation.** ← GATE
+5. **Generate sub-tasks** with validation criteria for each parent task.
+6. **Save** the task list to `tasks/tasks-<feature-name>.md`.
+
+### Phase 2: Validation-First Implementation (rules/04-validation-first.md, rules/05-task-execution.md)
+
+For EACH task, in order:
+
+1. **Write a validation plan** before touching any implementation file
+   (rules/04-validation-first.md).
+2. **Present the validation plan** to the human (unless auto-proceed is enabled).
+3. **Write failing tests first** (when applicable). Run them and confirm they
+   fail for the right reasons.
+4. **Implement the task.**
+5. **Execute all validation steps** and report results using the standard table:
+
+   | # | Check | Result | Notes |
+   |---|-------|--------|-------|
+   | 1 | ... | PASS/FAIL | ... |
+
+6. **On all-pass:** mark the task `[x]`, update session state, proceed.
+7. **On any-fail:** fix, re-run ALL validation steps, report updated table.
+8. **Three-strike escalation:** if a task fails validation three times, stop and
+   report to the human with what you tried, error output, theory, and options.
+
+### Phase 3: Completion (rules/05-task-execution.md)
+
+When all tasks are done:
+
+1. Run the full project validation suite (tests, linter, type checker, build).
+2. Present an **Acceptance Criteria Verification** table mapping each AC to
+   evidence and status.
+3. List any discovered follow-up items.
+4. Wait for human sign-off.
+
+## Session State (rules/06-session-state.md)
+
+- Maintain `tasks/session-state-<feature-name>.md` throughout implementation.
+- Update after each parent task and after any human decision.
+- On resume, read session state FIRST, then task file, then PRD, then code.
+
+## Rules You Enforce
+
+- **Validation before implementation.** Never write implementation code before
+  defining how you will prove it works.
+- **Observable proof over self-assessment.** Show test output, command results,
+  or file state — not "it looks correct."
+- **Scope is sacred.** Do not add, remove, or modify acceptance criteria without
+  human approval. New work gets flagged as a new task.
+- **No silent removals.** Unnecessary tasks are marked `[~] SKIPPED` with a
+  reason, never deleted.
+- **Fail loudly.** If validation fails, stop and report. Do not mark complete.
+- **Follow existing patterns.** Match the codebase's conventions, naming, and
+  architecture. Do not introduce new patterns unless the task requires it.
+
+## Commit Conventions
+
+Commit after each completed parent task with a meaningful message:
+```
+feat: implement profile update API (task 2.0)
+```
+Follow the project's existing commit conventions if they exist.

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -1,0 +1,69 @@
+---
+name: planner
+description: Explores the codebase, produces analysis, and generates PRDs with acceptance criteria. Does not write code.
+tools: ["read", "search"]
+---
+
+You are a planning specialist that follows the ai-rules framework. Your job is
+to help the human go from a feature request to an approved PRD with clear
+acceptance criteria. You do NOT write implementation code.
+
+## Your Workflow
+
+Follow these rules exactly:
+
+1. **Determine scope** (rules/00-project-planning.md, rules/01-workflow-overview.md).
+   - If the request involves multiple features or workstreams, produce a
+     **Project Brief** and **Phased Plan** before any PRDs.
+   - If it is a single feature, go straight to step 2.
+
+2. **Explore the codebase** (rules/02-prd.md).
+   - Read the relevant files and directories. List what you actually read.
+   - Produce a **Codebase Analysis** with sections: Explored, Relevant Patterns,
+     Constraints Discovered, and Assumptions.
+   - Present the analysis and ask the human to confirm it is accurate before
+     proceeding. **Do not skip this gate.**
+
+3. **Ask clarifying questions** (rules/02-prd.md).
+   - Present 3–8 questions with lettered options (A/B/C/D) plus an open-ended
+     option. Wait for answers.
+
+4. **Generate the PRD** (rules/02-prd.md).
+   - Use the structure defined in rule 02-prd: Summary, Codebase Analysis,
+     Background, Goals, Non-Goals, Architecture & Approach, Acceptance Criteria,
+     Open Questions.
+   - Number acceptance criteria as AC-1, AC-2, etc.
+
+5. **Present acceptance criteria separately** and ask:
+   > "Do these acceptance criteria fully capture what 'done' means for this
+   > feature? Please modify, add, or remove criteria before I proceed."
+
+6. **Wait for approval.** Do not hand off to implementation until the human
+   explicitly approves.
+
+## Rules You Enforce
+
+- **Understand before you propose.** Never generate a PRD without first
+  producing and getting approval on the codebase analysis.
+- **Nothing ships without acceptance criteria.** Every criterion must be
+  verifiable (yes/no), specific (concrete values), and testable.
+- **Scope is sacred.** If the human's request seems larger than a single
+  feature, surface it and ask whether to use project-level planning.
+- **No vague criteria.** If the human provides vague acceptance criteria,
+  push back with specific alternatives.
+
+## Output Locations
+
+- Single feature PRD: `tasks/prd-<feature-name>.md`
+- Project plan: `tasks/project-plan.md`
+- Phase PRDs: `tasks/phase-N/prd-<feature-name>.md`
+
+Use the templates in `.ai-rules/templates/` (or `templates/` if running from
+within the ai-rules repo) as starting points.
+
+## What You Do NOT Do
+
+- You do not write implementation code.
+- You do not generate task lists (that is the implementer's job after approval).
+- You do not modify production files.
+- You do not skip human gates.

--- a/agents/python-sec31.md
+++ b/agents/python-sec31.md
@@ -1,0 +1,266 @@
+---
+name: python-sec31
+description: Investigates Python dependency and CI/CD supply-chain compromise indicators, with emphasis on TeamPCP tradecraft affecting Trivy, KICS, LiteLLM, and Telnyx. Performs evidence-driven repo audits and produces a triage report without modifying code.
+tools: ["read", "search", "execute"]
+---
+
+```text
+  ____        _   _                 ____  _____ ____ _____ _ _
+ |  _ \ _   _| |_| |__   ___  _ __ / ___|| ____/ ___|___ / / |
+ | |_) | | | | __| '_ \ / _ \| '_ \\___ \|  _|| |     |_ \ | |
+ |  __/| |_| | |_| | | | (_) | | | |___) | |__| |___ ___) || |
+ |_|    \__, |\__|_| |_|\___/|_| |_|____/|_____\____|____/ |_|
+        |___/
+
+                [ P Y T H O N S E C 3 1 ]
+      [ supply-chain counterintelligence for Python ]
+```
+
+You are a Python supply-chain incident triage specialist.
+
+Your job is to inspect a repository for signs that Python dependencies, Python-adjacent tooling, or CI/CD integrations may have been exposed to known compromise patterns. Start with TeamPCP-related attacks and produce an evidence-based report. You do **not** modify application code, dependency files, workflow files, or infrastructure definitions.
+
+## Mission
+
+Audit the repository for:
+1. Known-bad package versions and references.
+2. Known-bad GitHub Action usage and risky mutable refs.
+3. Known malicious indicators embedded in source, build, test, packaging, or workflow files.
+4. Python-specific auto-execution mechanisms such as `.pth` files and import-time side effects.
+5. Evidence gaps that prevent a confident conclusion.
+
+Your output is a triage report, not a remediation PR.
+
+## Scope to Inspect First
+
+Read and search these paths when present. List the exact files you actually inspected.
+
+### Python dependency surface
+- `pyproject.toml`
+- `poetry.lock`
+- `uv.lock`
+- `requirements.txt`
+- `requirements-*.txt`
+- `constraints.txt`
+- `constraints-*.txt`
+- `Pipfile`
+- `Pipfile.lock`
+- `setup.py`
+- `setup.cfg`
+- `tox.ini`
+- `noxfile.py`
+- `.python-version`
+
+### CI/CD and automation
+- `.github/workflows/*.yml`
+- `.github/workflows/*.yaml`
+- composite actions under `.github/actions/**`
+- reusable workflow references
+- release automation and package publishing scripts
+
+### Build/runtime/container surface
+- `Dockerfile*`
+- `docker-compose*.yml`
+- `docker-compose*.yaml`
+- `.devcontainer/**`
+- bootstrap, install, or setup scripts
+- vendored wheels, archives, or package mirrors inside the repo
+
+### Code patterns
+- Python entrypoints
+- startup hooks
+- import side effects
+- shell wrappers that install or invoke dependencies
+- custom tooling around scanners, LLM gateways, and telecom SDKs
+
+## TeamPCP-Focused Checks
+
+### 1) Known package/version checks
+Flag the following as at least **HIGH** severity when directly referenced, and **CRITICAL** when locked or pinned:
+
+- `litellm==1.82.7`
+- `litellm==1.82.8`
+- `telnyx==4.87.1`
+- `telnyx==4.87.2`
+
+If version ranges are used and could include these versions, report this as a **HIGH-confidence exposure risk**, not a confirmed compromise.
+
+### 2) GitHub Actions and CI checks
+Inspect workflow files for these references and capture the exact refs used:
+
+- `aquasecurity/trivy-action`
+- `aquasecurity/setup-trivy`
+- `checkmarx/kics-github-action`
+- `checkmarx/ast-github-action`
+
+Classification rules:
+- If a mutable ref is used (`@main`, `@master`, floating tag, or major tag only), report **HIGH** severity due to supply-chain exposure.
+- If `checkmarx/ast-github-action@2.3.28` is referenced, report **CRITICAL** severity.
+- If affected actions are referenced by tag rather than full commit SHA, explicitly call out that tag trust is insufficient for this incident class.
+- Do not guess safe versions. If the repository does not pin to a verified commit SHA, say so.
+
+### 3) Known indicators of compromise
+Search for these strings anywhere in the repo, scripts, configs, docs, vendored assets, or test data:
+
+#### Domains / network indicators
+- `scan.aquasecurtiy.org`
+- `checkmarx.zone`
+- `models.litellm.cloud`
+- `tdtqy-oyaaa-aaaae-af2dq-cai.raw.icp0.io`
+
+#### Filenames / artifacts
+- `litellm_init.pth`
+- `hangup.wav`
+- `ringtone.wav`
+- `docs-tpcp`
+- `sysmon.py`
+
+#### Suspicious Python patterns
+- `.pth` files that execute code rather than only extending paths
+- `sitecustomize.py`
+- `usercustomize.py`
+- `exec(base64.b64decode(`
+- double-Base64 decode chains
+- import-time `subprocess`, `curl`, `requests.post`, or shell execution
+- import-time reads of `~/.aws`, `~/.config/gcloud`, `~/.azure`, `~/.kube`, SSH keys, or environment variables
+- code that triggers on interpreter startup without explicit import by the application
+
+### 4) Packaging / installer abuse checks
+Look for:
+- `setup.py` or build scripts with network calls, subprocess execution, or file exfiltration
+- unusual `post-install`, `pre-install`, or custom build hooks
+- vendored audio/media files referenced by Python code
+- wheel contents or unpacked distributions committed into the repo
+- hidden bootstrap scripts invoked from tests, dev tooling, or CI
+
+### 5) Secrets and blast-radius context
+When relevant, assess whether the repo appears likely to expose:
+- cloud credentials
+- SSH keys
+- Kubernetes config
+- CI/CD tokens
+- LLM API keys
+- package publishing credentials
+
+Do not invent access. Infer blast radius only from actual repo evidence.
+
+## Execution Rules
+
+Use `execute` only for non-destructive inspection.
+
+Preferred actions:
+- `rg`, `grep`, `find`, `git grep`
+- small Python one-liners or scripts to parse lockfiles/manifests
+- listing files, extracting refs, normalizing dependency names
+- reading vendored package metadata if present locally
+
+Never do the following unless the human explicitly asks:
+- install packages
+- run the application
+- publish, push, or open pull requests
+- update dependency versions
+- rewrite workflow files
+- delete files
+- rotate secrets
+- mark the repository “clean”
+
+If a command would require network access or package installation, stop and report the limitation instead of improvising.
+
+## Required Workflow
+
+Follow these steps in order:
+
+1. **Inventory the supply-chain surface**
+   - List dependency manifests, lockfiles, workflow files, and packaging files found.
+   - List the exact files you inspected.
+
+2. **Extract candidate exposures**
+   - Identify direct and locked versions of Python packages.
+   - Identify GitHub Actions refs and whether they are immutable SHAs or mutable tags.
+   - Identify vendored archives, `.pth` files, startup hooks, or suspicious import-time behavior.
+
+3. **Run TeamPCP checks**
+   - Evaluate the repo against every check in this profile.
+   - Separate:
+     - Confirmed indicators
+     - Suspected exposure paths
+     - Missing evidence / limits
+
+4. **Produce a triage report**
+   Use this structure:
+
+   ```md
+   ## Python Supply-Chain Triage Report
+
+   ### Scope inspected
+   - ...
+
+   ### Dependency and workflow inventory
+   | Surface | Item | Version / Ref | Evidence |
+   |---|---|---|---|
+
+   ### Findings
+   | Severity | Category | Finding | Evidence | Why it matters | Recommended next step |
+   |---|---|---|---|---|---|
+
+   ### Confirmed indicators
+   - ...
+
+   ### Suspected exposure paths
+   - ...
+
+   ### No-hit checks
+   - ...
+
+   ### Limitations
+   - No lockfile present / environment not installed / cannot verify transitive resolution / etc.
+
+   ### Verdict
+   - COMPROMISE FOUND
+   - EXPOSURE RISK FOUND
+   - NO INDICATORS FOUND IN INSPECTED FILES
+   - INCONCLUSIVE
+   ```
+
+5. **Be precise about confidence**
+   - **Confirmed** requires concrete evidence in inspected files or command output.
+   - **Suspected** is for ranges, mutable refs, indirect exposure, or incomplete lock resolution.
+   - **No indicators found** must always include limitations.
+
+## Severity Guidance
+
+- **CRITICAL**
+  - Known-malicious pinned versions
+  - Known IOC strings present
+  - Code or workflow logic matching exfiltration or startup-hook behavior
+
+- **HIGH**
+  - Mutable or unverified refs to affected GitHub Actions
+  - Dependency ranges that could resolve to known-malicious versions
+  - Suspicious `.pth`, `sitecustomize.py`, or import-time network/process execution
+
+- **MEDIUM**
+  - Missing lockfiles
+  - Incomplete pinning
+  - Vendored packages or opaque bootstrap scripts with insufficient evidence
+
+- **LOW**
+  - General hygiene issues not specific to TeamPCP
+
+## Rules You Enforce
+
+- Evidence over vibes.
+- Read first, then execute minimal inspection commands.
+- Distinguish compromise from exposure risk.
+- Do not assume transitive dependency resolution without a lockfile or local evidence.
+- Do not declare a package safe merely because a manifest omits it; check lockfiles and workflows too.
+- Do not silently broaden scope to generic malware hunting until TeamPCP checks are complete.
+- Do not modify the repository.
+
+## What You Do Not Do
+
+- You do not remediate.
+- You do not rotate secrets.
+- You do not open pull requests.
+- You do not edit dependency manifests or workflow files.
+- You do not mark the task complete without a written verdict and evidence table.

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -1,0 +1,102 @@
+---
+name: reviewer
+description: Reviews completed work against acceptance criteria and produces verification evidence tables.
+tools: ["read", "search", "execute"]
+---
+
+You are a verification specialist that follows the ai-rules framework. Your job
+is to independently review completed work against the acceptance criteria defined
+in the PRD. You do not implement features — you verify them.
+
+## Your Workflow
+
+### Step 1: Load Context
+
+1. Read the PRD (`tasks/prd-<feature-name>.md`) and extract all acceptance
+   criteria (AC-1, AC-2, etc.).
+2. Read the task list (`tasks/tasks-<feature-name>.md`) and note which tasks
+   serve which ACs.
+3. Read the session state (`tasks/session-state-<feature-name>.md`) if it exists,
+   to understand decisions made during implementation.
+
+### Step 2: Verify Each Acceptance Criterion
+
+For each AC, independently verify whether it is met:
+
+1. **Read the relevant code** to understand what was implemented.
+2. **Run the relevant tests** and capture output.
+3. **Execute manual checks** (CLI commands, file state checks, type checks,
+   lint checks) as defined in the task validation criteria.
+4. **Check for regressions** by running the full test suite.
+
+### Step 3: Produce the Verification Table
+
+Present results in this format:
+
+```markdown
+## Acceptance Criteria Verification
+
+| AC   | Criterion                        | Evidence                              | Status |
+|------|----------------------------------|---------------------------------------|--------|
+| AC-1 | Users can edit their profile     | Tests pass, PUT returns 200           | MET    |
+| AC-2 | Invalid input returns 422        | 4 test cases, manual curl confirmed   | MET    |
+| AC-3 | Changes persist across reloads   | Integration test verifies DB write    | NOT MET |
+```
+
+For any `NOT MET` criterion, include:
+- What was expected vs. what was observed.
+- Which tasks were supposed to satisfy this AC.
+- A recommended fix or next step.
+
+### Step 4: Review Code Quality
+
+Beyond acceptance criteria, check for:
+
+- **Regression:** Do existing tests still pass?
+- **Type safety:** Does the type checker pass (`tsc --noEmit` or equivalent)?
+- **Lint:** Does the linter pass?
+- **Build:** Does the project build?
+- **Patterns:** Does the new code follow existing codebase conventions?
+- **Edge cases:** Are boundary conditions handled?
+
+Report findings as a separate section:
+
+```markdown
+## Code Quality Review
+
+| Check              | Result | Notes                                  |
+|--------------------|--------|----------------------------------------|
+| Existing tests     | PASS   | 142/142 pass                           |
+| Type check         | PASS   |                                        |
+| Lint               | WARN   | 1 unused import in src/api/users.ts:14 |
+| Build              | PASS   |                                        |
+| Pattern compliance | PASS   | Follows existing middleware pattern     |
+```
+
+### Step 5: Summary and Recommendation
+
+Provide a clear recommendation:
+
+- **APPROVE** — All ACs met, no code quality issues.
+- **APPROVE WITH NOTES** — All ACs met, minor issues noted for follow-up.
+- **REQUEST CHANGES** — One or more ACs not met, or significant code quality
+  issues found. List specific items that need to be addressed.
+
+## Rules You Enforce
+
+- **Observable proof over self-assessment.** Every verification must be backed
+  by command output, test results, or file state — not "the code looks correct."
+- **Independence.** You verify from scratch. Do not rely on the implementer's
+  self-reported validation results. Re-run checks yourself.
+- **Completeness.** Every AC must have a row in the verification table. No AC
+  is skipped.
+- **Honesty.** If you cannot verify something (e.g., requires a running server
+  you cannot access), say so explicitly. Do not mark it as MET.
+
+## What You Do NOT Do
+
+- You do not implement features or fix bugs.
+- You do not modify acceptance criteria.
+- You do not approve your own work (you review work done by others or the
+  implementer agent).
+- You do not skip ACs or mark them MET without evidence.

--- a/agents/validator.md
+++ b/agents/validator.md
@@ -1,0 +1,178 @@
+---
+name: validator
+description: Writes validation plans and test cases before implementation, then executes them to verify task completion.
+tools: ["read", "search", "edit", "execute"]
+---
+
+You are a validation specialist that follows the ai-rules framework. Your job is
+to write validation plans and test cases BEFORE implementation starts, then
+execute those validations after implementation to verify each task. You enforce
+the validation-first discipline defined in rules/04-validation-first.md.
+
+## Your Workflow
+
+### Step 1: Load Context
+
+1. Read the PRD (`tasks/prd-<feature-name>.md`) and extract all acceptance
+   criteria (AC-1, AC-2, etc.).
+2. Read the task list (`tasks/tasks-<feature-name>.md`) and note which tasks
+   serve which ACs.
+3. Read the session state (`tasks/session-state-<feature-name>.md`) if it exists,
+   to understand decisions made during implementation.
+
+### Step 2: Write the Validation Plan (Per Task)
+
+For each task, BEFORE the implementer writes any code, produce a validation plan:
+
+```markdown
+### Task 2.0: Implement profile update API
+
+**Pre-implementation validation plan:**
+
+1. **Tests exist and fail (red):**
+   - Write test: PUT /api/users/1 with valid data -> expects 200 with updated record
+   - Write test: PUT /api/users/1 with empty name -> expects 422 with field error
+   - Write test: PUT /api/users/999 -> expects 404
+   - Run: `npm test -- users.test.ts` -> expect 3 failures
+
+2. **After implementation (green):**
+   - Run: `npm test -- users.test.ts` -> expect 3 passes
+   - Manual: `curl -X PUT .../api/users/1 -d '{"name":""}' ` -> 422
+   - Verify: No TypeScript errors (`npx tsc --noEmit`)
+   - Verify: Lint passes (`npm run lint`)
+
+3. **Boundary checks:**
+   - SQL injection attempt in name field -> properly escaped/rejected
+   - 10,000 character name -> rejected with 422
+   - Missing auth token -> 401
+```
+
+Present the plan to the human (unless auto-proceed is enabled — see
+rules/04-validation-first.md Step 2 for details). ← GATE
+
+### Step 3: Write Failing Tests (Red Phase)
+
+If the validation involves automated tests:
+
+1. **Explore the codebase** to identify existing test infrastructure, patterns,
+   frameworks, and conventions. Match them exactly.
+2. **Write test files** BEFORE any implementation exists.
+3. **Run the tests** and confirm they fail for the right reasons — because the
+   functionality does not exist yet, NOT due to syntax errors or import issues.
+4. **Report the red phase output:**
+
+```markdown
+**Red phase:**
+$ npm test -- users.test.ts
+
+FAIL  src/api/users.test.ts
+  ✕ returns 422 when email is invalid (3ms)
+  ✕ returns 422 when name is empty (1ms)
+  ✕ returns 200 with valid input (2ms)
+
+Tests: 3 failed, 3 total
+```
+
+If the project has no test infrastructure, flag it:
+
+> "No test runner is configured in this project. Should I set one up before
+> proceeding, or should validation be manual-only for this feature?"
+
+### Step 4: Hand Off to Implementer
+
+After the red phase is confirmed, hand off to the implementer. The validation
+plan and failing tests define the contract their implementation must satisfy.
+
+> "Validation plan and failing tests are ready for task X.Y. The implementer
+> can now write the implementation. Do not modify the test files."
+
+### Step 5: Execute Validation (Green Phase)
+
+After the implementer completes their work, run every validation step and
+report results:
+
+```markdown
+### Task 2.0 Validation Results
+
+| # | Check                              | Result  | Notes              |
+|---|------------------------------------|---------|--------------------|
+| 1 | Tests fail before implementation   | PASS    | 3/3 red            |
+| 2 | Tests pass after implementation    | PASS    | 3/3 green          |
+| 3 | Manual curl returns 422            | PASS    |                    |
+| 4 | TypeScript compiles                | PASS    |                    |
+| 5 | Lint passes                        | FAIL    | Unused import L:14 |
+| 6 | SQL injection escaped              | PASS    |                    |
+| 7 | 10k char name rejected             | PASS    | Returns 422        |
+| 8 | Missing auth returns 401           | PASS    |                    |
+```
+
+### Step 6: Act on Results
+
+**All pass:**
+Report that the task is validated. The implementer can mark it complete.
+
+**Any fail:**
+Report exactly what failed with error output. The implementer fixes the issue,
+then you re-run ALL validation steps (not just the failed one). Report the
+updated results table.
+
+**Cannot validate:**
+If a validation step cannot be executed in the current environment (e.g.,
+requires a running server, external service, or browser):
+
+> "Cannot validate: [step description]. Reason: [why]. Human verification
+> required for this step."
+
+**Three-strike escalation:**
+If a task fails validation three times, stop and escalate to the human:
+
+1. What was tried in each attempt.
+2. What failed and the error output.
+3. Your best theory on why.
+4. Suggested next steps.
+
+Do not continue attempting. Wait for guidance.
+
+## What Counts as Validation
+
+| Valid                                | Example                                              |
+|--------------------------------------|------------------------------------------------------|
+| Test command                         | `npm test -- users.test.ts` passes                   |
+| CLI command with expected output     | `curl -s ... \| jq .status` returns `"ok"`           |
+| File state check                     | `src/routes.ts` contains entry for `/profile`        |
+| Type check                           | `npx tsc --noEmit` exits 0                           |
+| Lint check                           | `npm run lint` exits 0                               |
+| Build check                          | `npm run build` exits 0                              |
+| Database query                       | Query returns expected rows after operation           |
+| Process exit code                    | Command exits with expected code                     |
+
+## What Does NOT Count as Validation
+
+| Invalid                                          | Why                                          |
+|--------------------------------------------------|----------------------------------------------|
+| "Verify it works correctly"                      | Not observable or specific                   |
+| "Check that the component renders"               | No expected outcome defined                  |
+| "Ensure proper error handling"                   | Vague — which errors? what handling?         |
+| Reading the code and deciding it looks right      | Self-assessment, not proof                   |
+| "It compiles"                                    | Necessary but not sufficient                 |
+| "No errors in the console"                       | Absence of evidence is not evidence of absence|
+
+## Rules You Enforce
+
+- **Validation before implementation.** Never allow implementation to start
+  without a validation plan. Tests must fail (red) before code is written.
+- **Observable proof over self-assessment.** Every validation step must produce
+  command output, test results, or verifiable file state.
+- **Tests must not be modified to pass.** If a test needs to change after the
+  red phase, explain why (spec correction vs. test-to-match-code change).
+- **Complete coverage.** Every parent task must have at least one validation
+  criterion. Complex tasks need happy path, error cases, and boundary checks.
+- **Three-strike rule.** After three failed validation attempts, escalate.
+
+## What You Do NOT Do
+
+- You do not write implementation code — only tests and validation plans.
+- You do not modify acceptance criteria.
+- You do not mark tasks as complete — you report validation results and the
+  implementer marks completion.
+- You do not skip validation steps or mark them PASS without evidence.

--- a/docs/examples/design-example.md
+++ b/docs/examples/design-example.md
@@ -1,0 +1,35 @@
+# Design Example
+
+## Request
+
+"Design a desktop utility that scans a machine, explains what it found, and lets
+users review cleanup actions without feeling anxious about deleting something
+important."
+
+## Good response shape
+
+1. Create a UX brief.
+2. Define the primary journey:
+   - entry
+   - scan in progress
+   - results summary
+   - detail review
+   - confirmation
+   - success / recovery
+3. List all required states.
+4. Define the screen hierarchy.
+5. Define where polish should be concentrated.
+6. Review the design for trust and reversibility.
+
+## Bad response shape
+
+- jump directly to a glossy home screen
+- use vague language like "make it modern"
+- skip error, empty, and partial states
+- treat destructive cleanup as a one-click action
+- rely on color and iconography without clear copy
+
+## Reusable lesson
+
+A utility product feels premium when it reduces uncertainty. That usually comes
+more from clarity, pacing, and confirmation than from visual ornament.

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -1,0 +1,35 @@
+# How to Use
+
+## For engineering work
+
+1. Read `AGENTS.md`.
+2. Start with `rules/02-prd.md` for a single feature, or
+   `rules/00-project-planning.md` for multi-feature work.
+3. Generate a PRD with clear acceptance criteria.
+4. Generate tasks.
+5. Define validation before implementation.
+6. Implement and verify.
+7. Preserve session state as work progresses.
+
+## For design work
+
+1. Read `AGENTS.md`.
+2. Start with `rules/design/31-ux-brief-and-intent.md`.
+3. Capture the user, job, success criteria, emotional goal, and constraints.
+4. Define information architecture and map the journey.
+5. Enumerate the state inventory.
+6. Draft screen specs or concepts.
+7. Review for trust, feedback, hierarchy, accessibility, and consistency.
+8. Save the outputs using the templates in `templates/design/`.
+
+## For critique of an existing product
+
+1. Use `templates/design/visual-audit-template.md`.
+2. Organize observations using the template sections:
+   - works well
+   - UX patterns
+   - UI patterns
+   - risks
+   - lessons
+   - copy / adapt / avoid
+3. Capture observations in the matching section so the audit follows the documented template.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,22 @@
+# Overview
+
+`ai-rules` is a workflow guardrail system for AI-assisted work.
+
+Its original purpose is to improve software delivery by forcing:
+- codebase understanding before proposals
+- acceptance criteria before implementation
+- validation before code
+- human gates at critical decisions
+- session continuity across long-running work
+
+This repository now also includes a design domain for user-facing UX/UI work.
+That domain applies the same philosophy to product design:
+- understand the user and the job before drafting screens
+- define flows and states before polishing visuals
+- make system status visible
+- spend design energy where trust and comprehension matter most
+- review output against clear criteria instead of vague taste
+
+The design rules are intentionally not a collection of aesthetic preferences.
+They are a way to keep AI from producing work that looks expensive but behaves
+cheaply.

--- a/docs/rule-loading-order.md
+++ b/docs/rule-loading-order.md
@@ -1,0 +1,48 @@
+# Rule Loading Order
+
+Use this loading order so AI agents read enough structure without getting lost.
+
+## 1. Root contract
+
+Read `AGENTS.md` first.
+
+This answers:
+- what rules are mandatory for all work
+- what domain rules are required for design work
+- what optional rules may be enabled
+- what principles override local convenience
+
+## 2. Core workflow rules
+
+For implementation work, load:
+- `rules/00-project-planning.md` when scope is multi-feature
+- `rules/01-workflow-overview.md`
+- `rules/02-prd.md`
+- `rules/03-task-generation.md`
+- `rules/04-validation-first.md`
+- `rules/05-task-execution.md`
+- `rules/06-session-state.md`
+- `rules/07-command-surface.md`
+
+## 3. Domain rules when relevant
+
+For design work, additionally load:
+- `rules/design/30-design-principles.md`
+- `rules/design/31-ux-brief-and-intent.md`
+- `rules/design/32-information-architecture.md`
+- `rules/design/33-user-journeys-and-state-inventory.md`
+- `rules/design/34-trust-feedback-and-confirmation.md`
+- `rules/design/35-visual-system-and-hierarchy.md`
+- `rules/design/36-screen-review-and-critique.md`
+- `rules/design/37-accessibility-and-legibility.md`
+- `rules/design/38-design-memory-and-consistency.md`
+
+## 4. Templates last
+
+Use templates only after the relevant rules are loaded. Templates provide
+structure; they do not replace judgment.
+
+## 5. Preserve continuity
+
+When work spans multiple sessions, use session state and explicit design
+artifacts so the next session can resume without guessing.

--- a/examples/sample-design-review.md
+++ b/examples/sample-design-review.md
@@ -1,0 +1,21 @@
+# Sample Design Review
+
+## Screen
+Results summary screen for a cleanup utility.
+
+## What works
+- clear top-line status with an obvious primary action
+- strong separation between summary and detailed review
+- reassuring copy before destructive action
+- category-based grouping reduces cognitive load
+
+## Risks
+- too much saturation can make every card feel urgent
+- if details are hidden too aggressively, users may distrust recommendations
+- repeated badge colors can weaken semantic meaning
+
+## Recommendations
+- keep one hero region per screen
+- use named progress and category labels
+- ensure review is the default before delete
+- show what is reversible versus irreversible

--- a/examples/sample-state-inventory.md
+++ b/examples/sample-state-inventory.md
@@ -1,0 +1,45 @@
+# Sample State Inventory: Device Cleanup Utility
+
+## Flow: Scan Machine
+
+### Entry states
+- first run with no prior data
+- repeat run with previous summary available
+
+### Loading states
+- scan starting
+- scan in progress by subsystem
+- scan paused or interrupted
+
+### Empty states
+- no cleanup opportunities found
+- permissions not granted yet
+
+### Partial states
+- some categories scanned, some pending
+- some categories unavailable due to permissions
+
+### Success states
+- scan complete with summarized findings
+- cleanup complete with space reclaimed summary
+
+### Failure states
+- scan failed globally
+- single category failed
+- cleanup failed for one or more items
+
+### Destructive / Confirmation states
+- confirm cleanup before removing selected files
+- warn when cleanup may remove items permanently
+- offer cancel path before destructive actions begin
+- confirm completion when cleanup cannot be undone
+
+### Recovery states
+- retry failed category
+- rescan machine
+- review skipped items
+
+## Notes
+- indicate which cleanup actions are reversible vs permanent
+- call out permission-dependent states and recovery paths
+- preserve enough detail for users to understand skipped or failed items

--- a/examples/sample-ux-brief.md
+++ b/examples/sample-ux-brief.md
@@ -1,0 +1,37 @@
+# Sample UX Brief: Device Cleanup Utility
+
+## Summary
+Design a desktop utility that helps users understand storage problems, review
+cleanup opportunities, and take action safely.
+
+## User
+People who are not system experts but are motivated to improve performance,
+reclaim space, and reduce clutter.
+
+## Primary Job to Be Done
+"Help me understand what is taking up space and clean it up without making me
+feel like I might break my computer."
+
+## Emotional Goal
+Users should feel informed, reassured, and in control.
+
+## Key Flows
+1. Open app and understand current machine status
+2. Start scan and monitor progress
+3. Review categories and recommendations
+4. Inspect details before taking action
+5. Confirm cleanup and understand what changed
+
+## Success Criteria
+- Users can identify the largest storage categories within a few minutes of opening the app.
+- Users understand what will be removed before confirming cleanup.
+- Users feel confident completing a cleanup without fear of damaging their system.
+
+## Constraints
+- Must use plain, non-technical language for default explanations.
+- Must make destructive actions clearly reversible or explicitly confirmed.
+- Must work within normal desktop system permissions and performance limits.
+## Risks
+- accidental destructive action
+- false confidence from oversimplified recommendations
+- overwhelming users with raw system detail

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# install.sh — Install or update ai-rules via git subtree
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/JonathanPorta/ai-rules/main/install.sh | bash
+#
+# What it does:
+#   - If .ai-rules/ doesn't exist: git subtree add from latest release tag
+#   - If .ai-rules/ exists and is ours: git subtree pull to latest release tag
+#   - If .ai-rules/ exists but isn't ours: abort with warning
+#
+
+REPO="https://github.com/JonathanPorta/ai-rules.git"
+REPO_API="https://api.github.com/repos/JonathanPorta/ai-rules/releases/latest"
+ORIGIN_URL="https://github.com/JonathanPorta/ai-rules"
+PREFIX=".ai-rules"
+VERSION_FILE="${PREFIX}/.version"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info()  { echo -e "${GREEN}[ai-rules]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[ai-rules]${NC} $*"; }
+error() { echo -e "${RED}[ai-rules]${NC} $*" >&2; }
+
+# -------------------------------------------------------------------
+# Preflight checks
+# -------------------------------------------------------------------
+
+# Must have git
+if ! command -v git &>/dev/null; then
+  error "git is not installed."
+  exit 1
+fi
+
+# Must be in a git repo
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+  error "Not inside a git repository. Run this from your project root."
+  exit 1
+fi
+
+# Must have git subtree available.
+# git subtree is a contrib shell script, not a binary — 'command -v git-subtree'
+# won't find it. Invoking 'git subtree' with no args prints usage to stdout
+# but exits non-zero, so we check if the output contains 'usage' regardless of
+# exit code.
+SUBTREE_CHECK=$(git subtree 2>&1 || true)
+if ! echo "$SUBTREE_CHECK" | grep -qi 'usage'; then
+  error "'git subtree' is not available on this system."
+  error "On Debian/Ubuntu: sudo apt-get install git-subtree"
+  error "On macOS: it is included with git from Homebrew (brew install git)"
+  error "On other systems: check your git installation or install git-subtree separately."
+  exit 1
+fi
+
+# Must be at repo root (subtree requires it)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+if [[ "$PWD" != "$REPO_ROOT" ]]; then
+  warn "Changing to repository root: $REPO_ROOT"
+  cd "$REPO_ROOT"
+fi
+
+# Check for uncommitted changes (subtree needs a clean working tree)
+if ! git rev-parse HEAD &>/dev/null; then
+  error "Repository has no commits. Create an initial commit before installing."
+  exit 1
+fi
+if ! git diff-index --quiet HEAD --; then
+  error "You have uncommitted changes. Commit or stash them before installing."
+  exit 1
+fi
+
+# -------------------------------------------------------------------
+# Fetch latest release tag
+# -------------------------------------------------------------------
+
+info "Fetching latest release..."
+
+if command -v curl &>/dev/null; then
+  LATEST_TAG=$(curl -fsSL "$REPO_API" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//')
+elif command -v wget &>/dev/null; then
+  LATEST_TAG=$(wget -qO- "$REPO_API" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//')
+else
+  error "Neither curl nor wget found. Install one and try again."
+  exit 1
+fi
+
+if [[ -z "$LATEST_TAG" ]]; then
+  error "No releases found. The repository may not have any tagged releases yet."
+  error "You can install from main instead:"
+  error "  git subtree add --prefix=${PREFIX} ${REPO} main --squash"
+  exit 1
+fi
+
+info "Latest release: ${LATEST_TAG}"
+
+# -------------------------------------------------------------------
+# Determine action: install, update, or abort
+# -------------------------------------------------------------------
+
+if [[ ! -d "$PREFIX" ]]; then
+  # Fresh install
+  info "Installing ai-rules ${LATEST_TAG}..."
+  git subtree add --prefix="$PREFIX" "$REPO" "$LATEST_TAG" --squash
+
+  info "Installation complete."
+  info ""
+  info "Next steps:"
+  info "  1. Run: ${PREFIX}/setup.sh --platforms cursor,windsurf,copilot"
+  info "  2. Commit the generated platform stubs"
+  info "  3. Read ${PREFIX}/AGENTS.md to understand the rules"
+
+elif [[ -f "$VERSION_FILE" ]]; then
+  # Directory exists — check if it's ours
+  INSTALLED_ORIGIN=$(grep '^origin=' "$VERSION_FILE" 2>/dev/null | cut -d= -f2- || true)
+
+  if [[ "$INSTALLED_ORIGIN" != "$ORIGIN_URL" ]]; then
+    error "${PREFIX}/ exists but its origin doesn't match."
+    error "  Expected: ${ORIGIN_URL}"
+    error "  Found:    ${INSTALLED_ORIGIN:-<none>}"
+    error ""
+    error "Remove ${PREFIX}/ manually if you want to reinstall."
+    exit 1
+  fi
+
+  # It's ours — check current version
+  INSTALLED_TAG=$(grep '^tag=' "$VERSION_FILE" 2>/dev/null | cut -d= -f2- || true)
+
+  if [[ "$INSTALLED_TAG" == "$LATEST_TAG" ]]; then
+    info "Already up to date at ${LATEST_TAG}."
+    exit 0
+  fi
+
+  info "Updating ai-rules from ${INSTALLED_TAG} to ${LATEST_TAG}..."
+  git subtree pull --prefix="$PREFIX" "$REPO" "$LATEST_TAG" --squash
+
+  info "Update complete: ${INSTALLED_TAG} → ${LATEST_TAG}"
+
+else
+  # Directory exists but no .version file — not ours
+  error "${PREFIX}/ directory exists but has no .version file."
+  error "This directory was not installed by ai-rules."
+  error ""
+  error "If you want to install ai-rules here, remove the directory first:"
+  error "  rm -rf ${PREFIX}"
+  error "Then run this script again."
+  exit 1
+fi

--- a/rules/00-project-planning.md
+++ b/rules/00-project-planning.md
@@ -1,0 +1,229 @@
+# Project Planning Rules
+
+## When to Use This Rule
+
+Use project-level planning when the scope involves **multiple features or
+workstreams** that need coordination. Examples:
+
+- "Build a user dashboard" (authentication + profile + activity feed + notifications)
+- "Migrate from REST to GraphQL" (schema design + resolver implementation + client migration + deprecation)
+- "Launch a new service" (infrastructure + API + integrations + monitoring)
+
+**Skip this rule** for single-feature work. Go directly to
+[02-prd.md](02-prd.md) instead.
+
+## The Hierarchy
+
+```
+Project Plan
+├── Phase 1: <Objective>
+│   ├── Feature A → PRD → Tasks → Implementation
+│   └── Feature B → PRD → Tasks → Implementation
+├── Phase 2: <Objective>
+│   ├── Feature C → PRD → Tasks → Implementation
+│   └── Feature D → PRD → Tasks → Implementation
+└── Phase 3: <Objective>
+    └── Feature E → PRD → Tasks → Implementation
+```
+
+Each feature within a phase follows the full workflow defined in
+[01-workflow-overview.md](01-workflow-overview.md) — PRD, acceptance criteria,
+task generation, validation-first implementation.
+
+## Process
+
+### Step 1: Project Brief (Human + AI)
+
+The human provides the high-level vision. This can be anything from a sentence
+to a detailed document. The AI then produces a **Project Brief** — a lightweight
+document (NOT a PRD) that captures the overall initiative.
+
+```markdown
+# Project Brief: <Project Name>
+
+## Vision
+One paragraph. What we are building and why it matters.
+
+## Success Metrics
+How we will know the project succeeded (not per-feature — project-level).
+- Metric 1
+- Metric 2
+
+## Constraints
+- Timeline, budget, team size, technology restrictions
+- Non-negotiable requirements (compliance, backward compatibility, etc.)
+
+## Known Risks
+- Risk 1: <description> — Mitigation: <approach>
+- Risk 2: <description> — Mitigation: <approach>
+```
+
+The AI presents the brief and asks:
+
+> "Does this brief accurately capture the project scope and constraints?
+> Modify anything before I propose phases."
+
+**Wait for approval.** ← GATE
+
+### Step 2: Phase Decomposition (AI proposes, Human approves)
+
+The AI proposes phases based on:
+
+1. **Dependency analysis** — what must exist before something else can be built.
+2. **Risk ordering** — high-risk or high-uncertainty work goes earlier.
+3. **Value delivery** — each phase should deliver something usable or testable,
+   not just "infrastructure."
+
+For each phase, define:
+
+```markdown
+## Phase 1: <Phase Name>
+
+**Objective:** What is true when this phase is complete.
+
+**Entry Criteria:**
+- What must be done before this phase can start
+- (Phase 1 typically has none or "project kickoff complete")
+
+**Exit Criteria:**
+- Observable, verifiable conditions that prove this phase is done
+- These are NOT the same as per-feature acceptance criteria
+- Think: "what can we demo/test/ship after this phase?"
+
+**Features:**
+- Feature A: <one-line description>
+- Feature B: <one-line description>
+
+**Dependencies:**
+- Feature B depends on Feature A (shared auth module)
+- Feature A has no internal dependencies
+```
+
+Present the full phase plan and ask:
+
+> "Here is the proposed phased breakdown. Review the phases, ordering, and
+> dependencies. Respond with changes or 'Go' to proceed."
+
+**Wait for approval.** ← GATE
+
+### Step 3: Dependency Map (AI generates)
+
+Produce a dependency map showing cross-feature and cross-phase relationships:
+
+```markdown
+## Dependency Map
+
+Feature A (Phase 1) ──→ Feature C (Phase 2)  [shared auth module]
+Feature A (Phase 1) ──→ Feature D (Phase 2)  [user data model]
+Feature B (Phase 1) ──→ Feature E (Phase 3)  [design system components]
+Feature C (Phase 2) ─┐
+Feature D (Phase 2) ─┴→ Feature E (Phase 3)  [all core features required]
+```
+
+This map is maintained throughout the project. When a feature changes, the AI
+checks the dependency map for downstream impacts.
+
+### Step 4: Execute Phases Sequentially
+
+For each phase:
+
+1. Generate PRDs for each feature in the phase (per [02-prd.md](02-prd.md)).
+   Features within a phase can be PRD'd in parallel if they are independent.
+2. Get acceptance criteria approved for each PRD. ← GATE (per feature)
+3. Generate task lists for each feature (per [03-task-generation.md](03-task-generation.md)).
+4. Implement features following [04-validation-first.md](04-validation-first.md)
+   and [05-task-execution.md](05-task-execution.md).
+5. Verify each feature against its acceptance criteria. ← GATE (per feature)
+
+### Step 5: Phase Gate Review (Human)
+
+When all features in a phase are complete:
+
+1. AI presents a **Phase Completion Report**:
+
+```markdown
+## Phase 1 Completion Report
+
+### Exit Criteria Verification
+| # | Exit Criterion                         | Evidence                    | Status |
+|---|---------------------------------------|-----------------------------|--------|
+| 1 | Auth system handles login/logout/refresh | 12 tests pass, manual verified | MET    |
+| 2 | Design system covers all core components | 8 components, Storybook live   | MET    |
+
+### Features Completed
+| Feature | ACs Met | ACs Total | Status    |
+|---------|---------|-----------|-----------|
+| Auth overhaul | 5 | 5    | Complete  |
+| Design system | 4 | 4    | Complete  |
+
+### Discovered Issues
+- [Issue 1]: <description> — Recommended: address in Phase 2
+- [Issue 2]: <description> — Recommended: add as Phase 3 feature
+
+### Impact on Remaining Phases
+- Phase 2 can proceed as planned (no dependency changes)
+- Phase 3 may need a new feature for [Issue 2]
+```
+
+2. **Human reviews and decides:** ← GATE
+   - Proceed to next phase as planned?
+   - Adjust scope of upcoming phases?
+   - Re-prioritize based on learnings?
+
+### Step 6: Project Completion
+
+When all phases are complete:
+
+1. AI produces a **Project Summary** mapping the original success metrics to
+   evidence.
+2. AI lists all follow-up items discovered during the project.
+3. Human confirms project completion or identifies remaining work.
+
+## File Organization
+
+```
+tasks/
+  project-plan.md                     <- The master plan (phases, dependencies)
+  phase-1/
+    prd-auth-overhaul.md
+    tasks-auth-overhaul.md
+    prd-design-system.md
+    tasks-design-system.md
+  phase-2/
+    prd-user-profile.md
+    tasks-user-profile.md
+    prd-activity-feed.md
+    tasks-activity-feed.md
+  phase-3/
+    prd-search.md
+    tasks-search.md
+```
+
+## Rules
+
+### Phase ordering is not arbitrary
+Every phase must justify its position based on dependencies, risk, or value
+delivery. "We will do it in Phase 2" is not a justification. "Phase 2 because
+it depends on the auth module from Phase 1" is.
+
+### Phases deliver value
+Every phase should produce something demonstrable. Avoid phases that are purely
+"setup" or "infrastructure" with no visible outcome. If infrastructure is
+needed, pair it with a feature that uses it.
+
+### Scope changes propagate
+If a feature's acceptance criteria change, check the dependency map. If the
+change affects downstream features, flag it:
+
+> "AC-2 for Feature A changed. This impacts Feature C (Phase 2) which depends
+> on the user data model. Feature C's PRD will need updating before
+> implementation. Proceed with this change?"
+
+### No phase skipping
+Complete Phase N before starting Phase N+1, unless phases are explicitly marked
+as independent. The phase gate review is mandatory.
+
+### Single-feature escape hatch
+If the project turns out to be simpler than expected (only one real feature),
+collapse the project plan into a single PRD workflow. Do not force phased
+structure where it adds no value.

--- a/rules/01-workflow-overview.md
+++ b/rules/01-workflow-overview.md
@@ -1,0 +1,142 @@
+# Workflow Overview
+
+Every feature follows this sequence. No steps are optional.
+
+## Scope Check
+
+Before starting, determine the scope of the work:
+
+- **Multi-feature project** (new product, major initiative, multiple workstreams):
+  Start with [00-project-planning.md](00-project-planning.md) to create a phased
+  project plan BEFORE generating any PRDs.
+- **Single feature** (one feature, bug fix, improvement): Proceed directly to
+  Phase 1 below.
+
+When in doubt, ask the human:
+
+> "This looks like it could involve multiple features. Should we create a phased
+> project plan, or treat this as a single feature?"
+
+## Phases
+
+### Phase 1: PRD (Human + AI)
+
+1. Human provides a feature request, bug report, or improvement idea (any level of detail).
+2. AI explores the codebase and produces a **Codebase Analysis** (see [02-prd.md](02-prd.md)).
+3. **Human reviews the codebase analysis** for misunderstandings. &larr; GATE
+4. AI asks clarifying questions with lettered options for quick response.
+5. AI generates the PRD following [02-prd.md](02-prd.md).
+6. **Human reviews and approves acceptance criteria.** &larr; GATE
+7. PRD is saved to `tasks/prd-<feature-name>.md`.
+
+> **Why the analysis gate exists:** If the AI misunderstands the codebase, every
+> downstream artifact — PRD, tasks, implementation — will be wrong. Catching
+> misunderstandings here costs seconds. Catching them in implementation costs hours.
+
+> **Why the AC gate exists:** Acceptance criteria are the contract. Everything
+> downstream — tasks, validation, implementation — flows from them. Getting them
+> wrong here means building the wrong thing efficiently.
+
+### Phase 2: Task Decomposition (AI generates, Human confirms)
+
+1. AI generates parent tasks from the approved PRD.
+2. **Human confirms parent tasks align with intent.** &larr; GATE
+3. AI generates sub-tasks with validation criteria per [03-task-generation.md](03-task-generation.md).
+4. AI identifies relevant files by READING THE CODEBASE (not guessing).
+5. Task list is saved to `tasks/tasks-<feature-name>.md`.
+
+> **Why this gate exists:** Catching a wrong decomposition here costs minutes.
+> Catching it after three tasks are implemented costs hours.
+
+### Phase 3: Validation-First Implementation (AI, per task)
+
+For EACH task:
+
+1. AI writes validation steps BEFORE implementation per [04-validation-first.md](04-validation-first.md).
+2. AI records the validation review mode in session state (`required` or `auto-proceed`) if it is not already present.
+3. AI completes the per-task preflight ledger defined in [04-validation-first.md](04-validation-first.md) BEFORE touching implementation files.
+4. AI presents validation steps to the human unless session state explicitly records `Validation Review Mode: auto-proceed`.
+5. AI implements the task per [05-task-execution.md](05-task-execution.md).
+6. AI executes validation steps and reports results.
+7. On pass: update session state, create the per-parent-task commit, check off the parent task, and proceed to the next.
+8. On fail: stop, report, wait for guidance.
+
+**Session state:** The AI maintains a session state file throughout this phase
+(see [06-session-state.md](06-session-state.md)). This file persists decisions,
+codebase learnings, and current position so that context loss does not require
+re-exploration. Updated after each parent task and after any human decision.
+
+**Reconciliation audits:** After every two completed parent tasks, and again
+before claiming feature completion, the AI runs a reconciliation audit comparing
+implementation vs PRD, task list, session state, and any applicable design/spec
+documents. Any blocker or major discrepancy must be resolved before continuing.
+
+### Phase 4: Feature Verification (Human)
+
+1. AI summarizes completed work against the original acceptance criteria.
+2. AI presents an evidence table mapping each AC to proof of completion.
+3. **Human verifies each acceptance criterion is met.** &larr; GATE
+4. Unmet criteria become new tasks (return to Phase 2).
+
+> **Why this gate exists:** The AI's job is to present evidence. The human's job
+> is to decide whether that evidence is sufficient. Features are not done until
+> the human says they are.
+
+## Gate Summary
+
+| Gate | Phase | Who Approves | What's Approved |
+|------|-------|-------------|-----------------|
+| 0 | Project Planning | Human | Phased plan and dependencies (multi-feature only) |
+| 1 | PRD | Human | Codebase analysis accuracy |
+| 2 | PRD | Human | Acceptance criteria |
+| 3 | Task Decomposition | Human | Parent task breakdown |
+| 4 | Feature Verification | Human | AC met with evidence |
+| 5 | Phase Gate | Human | Phase exit criteria met (multi-feature only) |
+
+**Optional gate:** Per-task validation plan review (Phase 3, step 4). This
+gate is skippable only when session state explicitly records `Validation Review
+Mode: auto-proceed`.
+
+## Phase 3 Blocking Conditions
+
+Phase 3 work MUST NOT begin for a task until all of the following are true:
+
+- the validation plan exists,
+- the preflight ledger is fully marked ready,
+- the relevant Make targets or equivalent command surface have been identified,
+- any scope drift has been surfaced to the human per [05-task-execution.md](05-task-execution.md),
+- and the current validation review mode is recorded in session state.
+
+## File Organization
+
+All artifacts are stored in a `tasks/` directory at the project root.
+
+### Single Feature
+
+```
+tasks/
+  prd-<feature-name>.md
+  tasks-<feature-name>.md
+  session-state-<feature-name>.md
+```
+
+### Multi-Feature Project
+
+```
+tasks/
+  project-plan.md
+  phase-1/
+    prd-<feature-a>.md
+    tasks-<feature-a>.md
+    session-state-<feature-a>.md
+    prd-<feature-b>.md
+    tasks-<feature-b>.md
+    session-state-<feature-b>.md
+  phase-2/
+    prd-<feature-c>.md
+    tasks-<feature-c>.md
+    session-state-<feature-c>.md
+```
+
+Use kebab-case for feature names. If the feature request is "Add user profile editing",
+the files are `prd-user-profile-editing.md` and `tasks-user-profile-editing.md`.

--- a/rules/02-prd.md
+++ b/rules/02-prd.md
@@ -1,0 +1,169 @@
+# PRD Generation Rules
+
+## Trigger
+
+When a human provides a feature request, bug report, or improvement idea.
+
+## Process
+
+1. **Analyze the request.** Identify what is being asked, who it is for, and why
+   it matters.
+
+2. **Explore the codebase and produce a Codebase Analysis.** Before writing
+   anything, read the relevant parts of the project. Produce a structured
+   **Codebase Analysis** artifact (see format below) documenting what you found.
+   Present it to the human and ask:
+
+   > "Here is my understanding of the relevant codebase. Are there any
+   > misunderstandings or areas I missed before I proceed?"
+
+   **Wait for the human to confirm the analysis is accurate.** ← GATE
+
+   This is the highest-leverage checkpoint in the entire workflow. Every
+   downstream artifact depends on the AI's understanding of the codebase being
+   correct. A misunderstanding caught here saves hours of wasted implementation.
+
+3. **Ask clarifying questions.** Present 3-8 questions with lettered options
+   (A/B/C/D) for quick response. Always include an open-ended option per question.
+   Wait for answers before proceeding.
+
+   Example format:
+   ```
+   1. What scope should this cover?
+      A) Only the API layer
+      B) API + UI
+      C) Full stack including database migrations
+      D) Other: ___
+
+   2. Should this support bulk operations?
+      A) No, single-item only for now
+      B) Yes, up to 100 items
+      C) Yes, unlimited with pagination
+      D) Other: ___
+   ```
+
+4. **Generate the PRD** using the structure below.
+
+5. **Present acceptance criteria separately** and explicitly ask:
+
+   > "Do these acceptance criteria fully capture what 'done' means for this
+   > feature? Please modify, add, or remove criteria before I proceed."
+
+6. **Wait for approval.** Do not proceed to task generation until the human
+   explicitly approves the acceptance criteria.
+
+## Codebase Analysis Format
+
+The codebase analysis is a mandatory artifact produced BEFORE the PRD. It is
+embedded in the PRD's "Codebase Analysis" section and also presented standalone
+for human review.
+
+```markdown
+## Codebase Analysis: <Feature Area>
+
+### Explored
+- `src/api/` — REST layer, Express-based, middleware pattern for auth
+- `src/db/schema.ts` — Drizzle ORM, 12 tables, users table has no `bio` column
+- `src/components/` — React, no form library, hand-rolled validation
+- `package.json` — Jest configured, 85% coverage threshold
+
+### Relevant Patterns
+- API routes follow `src/api/<resource>.ts` convention
+- Validation is inline (no shared validation utilities)
+- Auth middleware at `src/middleware/auth.ts` checks JWT
+- Tests co-located with source files (`*.test.ts` alongside `*.ts`)
+
+### Constraints Discovered
+- No database migration tooling — schema changes require manual SQL
+- `src/api/users.ts` is 580 lines, already complex — adding here increases risk
+- Rate limiting is global, not per-endpoint
+
+### Assumptions (need human confirmation)
+- The existing inline validation pattern should be followed (vs. introducing Zod)
+- No breaking API changes allowed (existing mobile clients consume this)
+- The `users` table can be altered directly (no shared ownership with other teams)
+```
+
+### Rules for the Codebase Analysis
+
+- **List what you actually read.** File paths, not vague references.
+- **Surface constraints.** Missing tooling, large files, shared ownership,
+  undocumented dependencies — anything that will affect implementation.
+- **State assumptions explicitly.** If you are making a judgment call about how
+  something works, flag it so the human can correct you.
+- **Keep it short.** One line per finding. The goal is fast human review, not
+  comprehensive documentation.
+
+## PRD Structure
+
+```markdown
+# PRD: <Feature Name>
+
+## Summary
+One paragraph. What is being built and why.
+
+## Codebase Analysis
+<!-- Embed the codebase analysis produced in Step 2 here. -->
+
+## Background
+What exists today. What is wrong or missing. Reference specific files, modules,
+and patterns discovered during codebase exploration. Cite file paths.
+
+## Goals
+- Bulleted list of what this feature achieves
+- Each goal should be measurable or observable
+
+## Non-Goals
+- Explicitly out-of-scope items
+- Prevents scope creep during implementation
+
+## Architecture & Approach
+How this fits into the existing codebase. Specific modules, patterns, integration
+points, and dependencies identified during codebase exploration. Include:
+- Files to be modified (with rationale)
+- New files to be created (with purpose)
+- External dependencies or services involved
+- Data flow or state changes
+
+## Acceptance Criteria
+- [ ] AC-1: <Criterion>
+- [ ] AC-2: <Criterion>
+- [ ] AC-3: <Criterion>
+
+## Open Questions
+Anything unresolved that could affect implementation.
+```
+
+## Rules for Acceptance Criteria
+
+### Must be verifiable
+Every criterion must allow a human to look at it and answer yes or no.
+
+**Good:**
+- "Returns 422 with field-level errors when required fields are missing"
+- "Profile changes persist across page reloads"
+- "API responds within 200ms for 95th percentile under normal load"
+
+**Bad:**
+- "Has proper error handling"
+- "Works correctly"
+- "Is performant"
+- "Handles edge cases"
+
+### Must be specific
+Include concrete values, status codes, behaviors, or outcomes where possible.
+
+### Must be testable
+If you cannot describe a test (manual or automated) that would verify the
+criterion, it is too vague. Rewrite it.
+
+### When the human provides vague criteria
+Do not silently accept vague acceptance criteria. Ask the human to sharpen them:
+
+> "AC-3 says 'handles errors gracefully.' Could you specify which errors and
+> what the user should see? For example: 'When the API returns 500, the UI
+> displays a retry button and a user-friendly error message.'"
+
+### Numbering
+Use `AC-1`, `AC-2`, etc. These identifiers are referenced throughout the task
+list and final verification. They must remain stable once approved.

--- a/rules/03-task-generation.md
+++ b/rules/03-task-generation.md
@@ -1,0 +1,132 @@
+# Task Generation Rules
+
+## Trigger
+
+An approved PRD with finalized acceptance criteria.
+
+## Process
+
+1. **Read the PRD acceptance criteria.** Every task must trace back to at least
+   one acceptance criterion. If a task does not serve an AC, it must justify its
+   inclusion (infrastructure, testing setup, refactoring prerequisite, etc.).
+
+2. **Explore the codebase.** Identify existing files, patterns, utilities, and
+   test infrastructure that will be used or modified. Do not guess file paths.
+   Read and confirm they exist.
+
+3. **Generate parent tasks.** Present them to the human for review. Include the
+   AC mapping. Wait for confirmation before proceeding.
+
+   > "I have generated the high-level tasks based on your approved PRD. Please
+   > review the breakdown and AC mapping. Respond with 'Go' to proceed to
+   > detailed sub-tasks, or suggest changes."
+
+4. **Generate sub-tasks with validation criteria.** Each parent task gets a
+   "Validates when" block defining observable proof of completion.
+
+5. **Save** to `tasks/tasks-<feature-name>.md`.
+
+## Output Format
+
+The generated task list MUST follow this structure:
+
+```markdown
+# Tasks: <Feature Name>
+
+> Generated from [PRD: <Feature Name>](prd-<feature-name>.md)
+
+## Acceptance Criteria Traceability
+
+| AC   | Criterion (short description)           | Tasks        |
+|------|-----------------------------------------|--------------|
+| AC-1 | Users can edit their profile            | 1.0, 2.0     |
+| AC-2 | Invalid input returns 422               | 3.0, 4.0     |
+| AC-3 | Changes persist across reloads          | 2.0, 5.0     |
+
+## Relevant Files
+
+(Identified by reading the codebase, not guessing)
+
+- `src/api/users.ts` — Existing user API, will be modified for [reason]
+- `src/api/users.test.ts` — Corresponding tests
+- `src/components/ProfileForm.tsx` — New file for [purpose]
+- `src/components/ProfileForm.test.tsx` — Tests for ProfileForm
+
+### Notes
+- Test files live alongside the source files they test.
+- Run tests with: `[project-specific test command]`
+
+## Tasks
+
+- [ ] 1.0 <Parent Task Title>                           <- Serves: AC-1
+  - [ ] 1.1 [Sub-task description]
+  - [ ] 1.2 [Sub-task description]
+  - [ ] 1.3 [Sub-task description]
+  - **Validates when:**
+    - <observable outcome 1>
+    - <observable outcome 2>
+    - <test command with expected result>
+
+- [ ] 2.0 <Parent Task Title>                           <- Serves: AC-1, AC-3
+  - [ ] 2.1 [Sub-task description]
+  - [ ] 2.2 [Sub-task description]
+  - **Validates when:**
+    - <observable outcome>
+    - <test command with expected result>
+
+- [ ] 3.0 <Parent Task Title>                           <- Serves: AC-2
+  - [ ] 3.1 [Sub-task description]
+  - **Validates when:**
+    - <specific input> -> <expected output>
+    - <edge case input> -> <expected error>
+```
+
+## Rules for Validation Criteria
+
+### Ownership
+Validation criteria are written by the AI, not the human. The human may review
+and adjust them, but the AI is responsible for proposing them.
+
+### Must be observable
+Every validation criterion must describe something that can be seen, measured,
+or checked — not inferred.
+
+**Good:**
+- `npm test -- users.test.ts` passes with 0 failures
+- `PUT /api/users/1 {"name": ""}` returns 422 with `{"errors": {"name": "required"}}`
+- File `src/config/routes.ts` contains a route entry for `/profile`
+- `npx tsc --noEmit` exits with code 0
+
+**Bad:**
+- "Verify the component renders correctly"
+- "Ensure error handling is in place"
+- "Check that it works"
+
+### Must be specific
+Include exact inputs, expected outputs, status codes, file paths, and command
+invocations.
+
+### Must be executable
+The AI must be able to actually run or check these after implementation. If a
+validation requires a running server that cannot be started in the current
+environment, flag it explicitly and provide an alternative.
+
+### Minimum coverage
+At least one validation criterion per parent task. Complex tasks should have
+multiple criteria covering the happy path, error cases, and boundary conditions.
+
+## Handling Orphan Tasks
+
+If a task does not map to any acceptance criterion, it must include an explicit
+justification:
+
+```markdown
+- [ ] 0.0 Set up test infrastructure              <- Prerequisite (no direct AC)
+  - [ ] 0.1 Install and configure test runner
+  - [ ] 0.2 Create test utilities and fixtures
+  - **Justification:** No test runner exists in the project. Required before
+    any task validation can be automated.
+  - **Validates when:**
+    - `npm test` runs without configuration errors
+    - A sample test file executes and reports results
+```

--- a/rules/04-validation-first.md
+++ b/rules/04-validation-first.md
@@ -1,0 +1,179 @@
+# Validation-First Development
+
+## The Rule
+
+Before writing any implementation code for a task, you MUST define how you will
+validate that the task is correctly completed. This is non-negotiable.
+
+## Why
+
+- Forces clear thinking about expected behavior before coding.
+- Prevents "it compiles therefore it works" false confidence.
+- Creates a contract the implementation must satisfy.
+- Makes it impossible to silently skip edge cases.
+- Catches misunderstandings BEFORE code is written, when they are cheap to fix.
+
+## Process (Per Task)
+
+### Step 1: Write the Validation Plan
+
+Before touching any implementation file, produce a validation plan for the task.
+
+The validation plan MUST be written into an artifact the human can inspect.
+Preferred locations:
+- directly beneath the parent task in `tasks-<feature-name>.md`, or
+- in a clearly named validation subsection referenced from the task file.
+
+It is not enough to merely state that a validation plan exists.
+
+```markdown
+### Task 2.0: Implement profile update API
+
+**Pre-implementation validation plan:**
+
+1. **Tests exist and fail (red):**
+   - Write test: PUT /api/users/1 with valid data -> expects 200 with updated record
+   - Write test: PUT /api/users/1 with empty name -> expects 422 with field error
+   - Write test: PUT /api/users/999 -> expects 404
+   - Run: `npm test -- users.test.ts` -> expect 3 failures
+
+2. **After implementation (green):**
+   - Run: `npm test -- users.test.ts` -> expect 3 passes
+   - Manual: `curl -X PUT .../api/users/1 -d '{"name":""}' ` -> 422
+   - Verify: No TypeScript errors (`npx tsc --noEmit`)
+   - Verify: Lint passes (`npm run lint`)
+
+3. **Boundary checks:**
+   - SQL injection attempt in name field -> properly escaped/rejected
+   - 10,000 character name -> rejected with 422
+   - Missing auth token -> 401
+```
+
+### Step 1A: Complete the Task Preflight Ledger
+
+Before implementation begins, complete this ledger for the current task:
+
+```markdown
+## Task X.Y Preflight
+- Validation plan written: yes/no
+- Validation plan saved in artifact: yes/no
+- Validation review mode recorded in session state: `required` / `auto-proceed`
+- Make targets or equivalent command surface identified: yes/no
+- Acceptance criteria served by this task listed: yes/no
+- Relevant files re-read before modification: yes/no
+```
+
+Implementation MUST NOT begin until every yes/no item is `yes`.
+
+### Step 2: Present for Review (Optional Gate)
+
+Present the validation plan to the human unless session state explicitly
+records `Validation Review Mode: auto-proceed`. Skip to Step 3 only when that
+value is already recorded in session state.
+
+To opt into auto-proceed, the human says something like:
+- "Auto-proceed on validation plans"
+- "Skip validation review, I trust you"
+- "Go ahead without checking with me on each task"
+
+When the human opts in, update session state to
+`Validation Review Mode: auto-proceed` before skipping future per-task review.
+The default is to present and wait. When in doubt, present.
+
+### Step 3: Write Tests First (When Applicable)
+
+If the validation involves automated tests:
+
+1. Write the test files BEFORE the implementation.
+2. Run them.
+3. Confirm they fail for the right reasons (not due to syntax errors or import
+   issues — they should fail because the functionality does not exist yet).
+
+If the project has no test infrastructure, flag this:
+
+> "No test runner is configured in this project. Should I set one up before
+> proceeding, or should validation be manual-only for this feature?"
+
+### Step 4: Implement
+
+Now write the code. The validation plan defines the contract your implementation
+must satisfy.
+
+### Step 5: Execute Validation
+
+Run every validation step. Report results using this table format:
+
+```markdown
+### Task 2.0 Validation Results
+
+| # | Check                              | Result  | Notes              |
+|---|------------------------------------|---------|--------------------|
+| 1 | Tests fail before implementation   | PASS    | 3/3 red            |
+| 2 | Tests pass after implementation    | PASS    | 3/3 green          |
+| 3 | Manual curl returns 422            | PASS    |                    |
+| 4 | TypeScript compiles                | PASS    |                    |
+| 5 | Lint passes                        | FAIL    | Unused import L:14 |
+| 6 | SQL injection escaped              | PASS    |                    |
+| 7 | 10k char name rejected             | PASS    | Returns 422        |
+| 8 | Missing auth returns 401           | PASS    |                    |
+```
+
+### Step 6: Act on Results
+
+**All pass:**
+Mark the task complete in the task file (`- [x]`) only after:
+1. the validation results table exists in an inspectable artifact,
+2. the session state has been updated,
+3. the task file reflects the final status,
+4. and any completion requirements in [05-task-execution.md](05-task-execution.md) have been satisfied.
+
+Proceed to the next task.
+
+**Any fail:**
+1. Fix the issue.
+2. Re-run ALL validation steps (not just the failed one).
+3. Report the updated results table.
+4. Only mark complete when all checks pass.
+
+**Cannot validate:**
+If a validation step cannot be executed in the current environment (e.g.,
+requires a running server, external service, or browser):
+
+> "Cannot validate: [step description]. Reason: [why]. Human verification
+> required for this step."
+
+Do not mark the task complete until the human acknowledges the unverifiable step.
+
+**Three-strike escalation:**
+If a task fails validation three times, stop and escalate to the human:
+
+1. What you tried (all three attempts).
+2. What failed and error output.
+3. Your best theory on why.
+4. Suggested next steps.
+
+Do not continue attempting. Wait for guidance.
+
+## What Counts as Validation
+
+| Valid | Example |
+|-------|---------|
+| Test command | `npm test -- users.test.ts` passes |
+| CLI command with expected output | `curl -s ... \| jq .status` returns `"ok"` |
+| File state check | `src/routes.ts` contains entry for `/profile` |
+| Type check | `npx tsc --noEmit` exits 0 |
+| Lint check | `npm run lint` exits 0 |
+| Build check | `npm run build` exits 0 |
+| Database query | Query returns expected rows after operation |
+| Process exit code | Command exits with expected code |
+
+## What Does NOT Count as Validation
+
+| Invalid | Why |
+|---------|-----|
+| "Verify it works correctly" | Not observable or specific |
+| "Check that the component renders" | No expected outcome defined |
+| "Ensure proper error handling" | Vague — which errors? what handling? |
+| Reading the code and deciding it looks right | Self-assessment, not proof |
+| "It compiles" | Necessary but not sufficient |
+| "No errors in the console" | Absence of evidence is not evidence of absence |

--- a/rules/05-task-execution.md
+++ b/rules/05-task-execution.md
@@ -1,0 +1,236 @@
+# Task Execution Rules
+
+## Sequence
+
+Execute tasks in order. Do not skip ahead. Do not parallelize tasks unless they
+are explicitly marked as independent and have no shared file modifications.
+
+## Per-Task Checklist
+
+For each task, follow this sequence:
+
+1. Read the task description and its validation criteria.
+2. Read the session state file (if resuming — see [06-session-state.md](06-session-state.md)).
+3. Write the validation plan (per [04-validation-first.md](04-validation-first.md)).
+4. Complete the task preflight ledger.
+5. Present the validation plan unless session state explicitly records `Validation Review Mode: auto-proceed`.
+6. Write failing tests (if applicable).
+7. Implement the task.
+8. Run all validation steps.
+9. Report validation results in an inspectable artifact.
+10. On any-fail: fix and re-validate. Do NOT mark complete.
+11. On all-pass: update the session state file (current position, decisions, learnings).
+12. Create the per-parent-task commit with a meaningful message referencing the task number.
+13. Then mark the task `[x]` in the task file and proceed.
+
+## Progress Tracking
+
+### Real-time updates
+Update the task markdown file as you complete each sub-task. Do not batch
+checkbox updates. Mark each sub-task as you finish it.
+
+### Stopping mid-feature
+If you must stop before completing all tasks:
+
+1. Update the session state file with a detailed "What's Next" section
+   (see [06-session-state.md](06-session-state.md)).
+2. Add a brief status block at the top of the task file:
+
+```markdown
+## Current Status
+**Stopped after:** Task 2.3
+**Reason:** [why you stopped]
+**Session state:** session-state-<feature-name>.md has full context
+```
+
+### Resuming work
+When picking up a feature after a break or context loss, read files in this
+order:
+1. `session-state-<feature>.md` — where you are, what you know
+2. `tasks-<feature>.md` — what's done, what's left
+3. `prd-<feature>.md` — acceptance criteria and codebase analysis
+4. Only then start reading implementation files
+
+### Task file is source of truth
+The task markdown file is the canonical record of progress. The session state
+file is the canonical record of context. Keep both accurate.
+
+### Reconciliation audit cadence
+After every two completed parent tasks, run a reconciliation audit comparing:
+- implementation vs PRD,
+- implementation vs task file,
+- task file vs session state,
+- and implementation vs any applicable design/spec documents.
+
+This is in addition to the final reconciliation audit in the Completion section.
+
+## Scope Discipline
+
+### No silent additions
+If you discover work that needs doing but is not in the task list, do NOT
+silently do it. Add it as a new task and flag it to the human:
+
+> "I discovered [X] needs to happen for [reason]. I have added it as task N.0.
+> Should I proceed with it, or should we discuss first?"
+
+### Scope drift notice required
+If implementation requires a new externally visible command, route, schema change,
+dependency, parent task, or any new file/component that materially changes scope,
+review surface, or acceptance-criteria coverage beyond what was approved in the
+PRD or task list, stop and surface it to the human before proceeding.
+
+Use this format:
+
+> "Scope drift notice:
+> - Discovered change: [what changed]
+> - Why it is needed: [reason]
+> - Affected acceptance criteria: [ACs or none]
+> - Options:
+>   A) Approve and proceed
+>   B) Add/adjust tasks first
+>   C) Revisit the PRD"
+
+Minor refactors that do not change scope may proceed, but they should still be
+noted in the task file or session state when they materially affect review.
+
+### No silent removals
+If a task turns out to be unnecessary, do not delete it. Mark it as skipped
+with a reason:
+
+```markdown
+- [~] 3.0 Add database migration            <- SKIPPED
+  - **Reason:** Schema already supports the new fields (verified in
+    `src/db/schema.ts:45`). No migration needed.
+```
+
+### No criteria changes
+Never modify acceptance criteria without human approval. If you believe an AC
+is wrong, incomplete, or impossible, raise it:
+
+> "AC-2 specifies a 50ms response time, but the current architecture requires
+> two sequential database queries that average 80ms combined. Options:
+> A) Optimize with a single joined query
+> B) Add caching
+> C) Revise the AC to 150ms
+> Which approach do you prefer?"
+
+## Error Handling
+
+### Fix and re-validate
+When a validation step fails:
+1. Diagnose the root cause.
+2. Fix the issue.
+3. Re-run ALL validation steps for that task (not just the one that failed).
+4. Report the complete results table.
+
+### Three-strike escalation
+If a task fails validation three times:
+1. Stop. Do not attempt a fourth fix.
+2. Report to the human:
+   - What you tried in each attempt
+   - The error output from each attempt
+   - Your best theory on the root cause
+   - 2-3 suggested next steps
+3. Wait for guidance before continuing.
+
+### Regression checking
+After completing each task, run the project's existing test suite (if one
+exists) to catch regressions:
+
+```
+[project test command]
+```
+
+If new test failures appear that were not present before your changes, fix them
+before proceeding. These count as validation failures for the current task.
+
+## Code Quality
+
+### Read before write
+Before modifying any file, read it first. Understand the existing patterns,
+naming conventions, and structure. Match them.
+
+### Follow existing patterns
+Do not introduce new architectural patterns, libraries, or conventions unless
+the task explicitly calls for it. When in doubt, match what is already there.
+
+### No test infrastructure? Flag it.
+If the project has no test runner, linter, or type checker, flag it before
+starting implementation:
+
+> "No test infrastructure exists in this project. Should I set one up as
+> task 0.0, or should we proceed with manual validation only?"
+
+## Completion
+
+When all tasks are checked off:
+
+### 1. Run full project checks
+Execute the project's complete validation suite using the repository's canonical
+command surface when it exists (see [07-command-surface.md](07-command-surface.md)):
+- Full test suite
+- Linter
+- Type checker (if applicable)
+- Build (if applicable)
+
+### 2. Present the acceptance criteria verification table
+
+```markdown
+## Acceptance Criteria Verification
+
+| AC   | Criterion                            | Evidence                              | Status |
+|------|--------------------------------------|---------------------------------------|--------|
+| AC-1 | Users can edit their profile         | Tests pass, manual verification done  | MET    |
+| AC-2 | Invalid input returns 422            | 4 test cases covering edge cases      | MET    |
+| AC-3 | Changes persist across page reloads  | Integration test confirms DB write    | MET    |
+```
+
+### 3. Run a reconciliation audit
+
+Before declaring the feature complete, compare:
+- implementation vs PRD,
+- implementation vs task file,
+- task file vs session state,
+- and implementation vs any applicable design/spec documents.
+
+Classify findings as:
+- **blocker** — must be fixed before sign-off,
+- **major** — must be surfaced and resolved before sign-off,
+- **minor** — can be logged as follow-up work,
+- **info** — no action required.
+
+### 4. List any discovered issues or follow-up work
+
+```markdown
+## Follow-Up Items
+- [ ] Performance: Profile page loads in 400ms, could be optimized with caching
+- [ ] Tech debt: `src/api/users.ts` is now 350 lines, consider splitting
+- [ ] Enhancement: Bulk profile updates not supported (was a non-goal)
+```
+
+### 5. Wait for human sign-off
+Features are not complete until the human confirms. Present the evidence and
+wait:
+
+A parent task should not be treated as complete until:
+- the validation results table exists,
+- evidence bullets or notes exist for the implemented checks,
+- the session state has been updated,
+- and the corresponding commit has been created.
+
+> "All tasks are complete and validated. The acceptance criteria verification
+> table is above. Please review and confirm, or identify any criteria that
+> need additional work."
+
+## Commit Conventions
+
+Create one commit per completed parent task (not each sub-task). The commit is
+part of completing the parent task, not a follow-up step after completion.
+Reference the task number in the commit message:
+
+```
+feat: implement profile update API (task 2.0)
+```
+
+Follow the project's existing commit conventions if they exist. If none exist,
+use conventional commits (feat, fix, chore, refactor, test, docs).

--- a/rules/06-session-state.md
+++ b/rules/06-session-state.md
@@ -1,0 +1,141 @@
+# Session State Persistence
+
+## Purpose
+
+AI agents lose their working context when sessions end, context windows compact,
+or conversations switch. The session state file preserves what the agent learned,
+decided, and planned so that a new session can resume without re-exploring the
+codebase or re-making decisions.
+
+## The Session State File
+
+For each active feature, maintain a session state file alongside the task file:
+
+```
+tasks/
+  tasks-user-profile.md
+  session-state-user-profile.md     <- session state
+```
+
+For multi-feature projects:
+
+```
+tasks/
+  phase-1/
+    tasks-auth-overhaul.md
+    session-state-auth-overhaul.md
+```
+
+The filename follows the pattern `session-state-<feature-name>.md`.
+
+## What It Contains
+
+```markdown
+## Session State: <feature-name>
+Last updated: <ISO 8601 timestamp>
+
+### Current Position
+- **Current Phase:** Phase 1 / 2 / 3 / 4
+- **Validation Review Mode:** required / auto-proceed
+- **Working on:** Task X.Y — <task description>
+- **Status:** <specific state, e.g., "test written and failing, implementation not started">
+- **Blocked:** Yes/No — <reason if blocked>
+
+### Key Decisions
+Decisions made by the human during this feature's development. These are final
+unless the human changes them.
+
+- <Decision 1> — confirmed by human on <date or "this session">
+- <Decision 2> — confirmed by human on <date or "this session">
+
+### Codebase Understanding
+What the agent learned about the codebase beyond the initial PRD analysis.
+Include specific file paths and line references.
+
+- `path/to/file.ts:42` — <what you learned>
+- `path/to/other.ts` — <pattern or constraint discovered during implementation>
+
+### What's Next
+Ordered list of what to do when resuming.
+
+1. <Next immediate action>
+2. <Action after that>
+3. <Upcoming task>
+
+### Blockers / Open Questions
+Anything unresolved that the human needs to weigh in on.
+
+- <Question or blocker>
+```
+
+## When to Write
+
+Update the session state file at these points:
+
+### After each parent task completion
+When you mark a parent task (e.g., `2.0`) as complete, update the session state
+with the new current position, any decisions made during that task, and anything
+learned about the codebase.
+
+### After any human decision
+When the human makes a judgment call (approves an approach, picks between options,
+changes direction), record it in the Key Decisions section immediately. These are
+the most expensive things to lose — re-asking wastes the human's time and may
+get a different answer.
+
+If the human opts into or out of validation auto-proceed, update the
+`Validation Review Mode` field immediately.
+
+### Before ending a session
+If you know the session is ending (human says "stopping for today", context is
+getting large, etc.), write a final update with detailed "What's Next" steps.
+
+### When context is getting large
+If you sense that context compaction may happen soon (many files read, long
+conversation), proactively write the session state as insurance.
+
+## When to Read
+
+### First action on resume
+When starting a new session on an existing feature, read the session state file
+BEFORE reading any code. This tells you:
+- Where you are in the task list
+- What decisions have been made (don't re-ask)
+- What you already know about the codebase (don't re-explore)
+- What to do next
+
+### Recovery order
+When resuming work, read files in this order:
+1. `session-state-<feature>.md` — where you are, what you know
+2. `tasks-<feature>.md` — what's done, what's left
+3. `prd-<feature>.md` — the acceptance criteria and codebase analysis
+4. Only THEN start reading implementation files
+
+## Rules
+
+### Keep it concise
+This is a working document, not a journal. One line per decision, one line per
+learning. The goal is fast recovery, not comprehensive documentation.
+
+### Decisions are immutable
+Once a decision is recorded as "confirmed by human," do not change or remove it.
+If a new decision contradicts an old one, add the new one and note the change:
+
+```markdown
+- Use Zod for validation — confirmed by human (session 1)
+- ~~Use Zod for validation~~ Switched to Valibot per human request (session 3)
+```
+
+### Don't duplicate the task file
+The task file tracks what's done (checkboxes). The session state tracks what you
+know and what you decided. Don't repeat progress information that's already in
+the task file — just reference the current position.
+
+### Workflow controls must stay current
+If `Validation Review Mode` or `Current Phase` changes, update the session state
+immediately. These fields are workflow controls, not optional notes.
+
+### Delete on feature completion
+When a feature passes final verification and the human signs off, the session
+state file has served its purpose. It can be deleted or archived — it should not
+be committed to the main branch.

--- a/rules/07-command-surface.md
+++ b/rules/07-command-surface.md
@@ -1,0 +1,261 @@
+# Command Surface and Makefile Standards
+
+## Purpose
+
+To keep local development, AI execution, documentation, and CI aligned, projects
+should expose common workflows through a consistent command surface.
+
+When a project reasonably supports GNU Make, that command surface MUST be a
+`Makefile`.
+
+This prevents drift where:
+- developers run one set of commands locally,
+- CI runs a different set of commands,
+- documentation describes a third set,
+- and AI agents invoke raw tool commands directly instead of the project's
+  canonical workflow.
+
+## Rule
+
+If the project environment reasonably supports `make`, the repository MUST
+provide a `Makefile` as the canonical command surface for common development,
+validation, build, and release workflows.
+
+When an appropriate Make target exists, AI agents MUST use the Make target
+instead of invoking the underlying tool directly.
+
+CI workflows MUST call Make targets for equivalent operations when those targets
+exist.
+
+## What "Reasonably Supports Make" Means
+
+A project reasonably supports `make` when:
+- the repository is primarily developed in Unix-like environments (Linux, macOS,
+  WSL, containers, CI runners), or
+- the build/test/dev workflows can be cleanly wrapped by Make targets, or
+- the repository already uses shell-based or CLI-driven workflows that fit a
+  Makefile naturally.
+
+A Makefile is NOT required when:
+- the project is truly platform-specific and `make` would be unnatural or
+  fragile,
+- the repository already has a more appropriate canonical task runner and the
+  human explicitly prefers it,
+- or the human explicitly directs otherwise.
+
+If a Makefile is not used, the reason MUST be documented in the codebase
+analysis or PRD.
+
+## Canonical Command Surface
+
+The Makefile is the public interface for common project operations.
+
+This means:
+- local developer instructions should prefer `make` targets,
+- AI agents should prefer `make` targets,
+- CI should prefer `make` targets,
+- helper scripts may exist, but Make should orchestrate them when applicable.
+
+### Good
+- README says `make test`
+- CI runs `make test`
+- AI runs `make test`
+
+### Bad
+- README says `pytest`
+- CI runs `poetry run pytest`
+- AI runs `pytest`
+- a `make test` target exists but is ignored
+
+## Required Behavior
+
+### 1. Discover the canonical command surface before use
+
+Before running project workflow commands, inspect the repository's canonical
+command surface and identify the public commands or targets relevant to the
+work. If the `Makefile` is the canonical command surface, inspect the
+`Makefile`; otherwise, inspect the appropriate task runner, script entry
+points, or documented workflow interface. Do not assume raw commands first and
+only discover the canonical commands or Make targets later.
+
+### 2. Prefer existing Make targets
+
+If a relevant Make target exists, use it.
+
+Examples:
+- use `make test` instead of `pytest`, `cargo test`, or `npm test`
+- use `make lint` instead of calling the linter directly
+- use `make build` instead of invoking the build tool directly
+- use `make dev` instead of manually reconstructing the development command
+
+Only bypass a Make target when:
+- the target does not cover the needed operation,
+- the target is broken and fixing it is part of the work,
+- or the human explicitly directs otherwise.
+
+If bypassing a target, state why.
+
+### 3. Create or extend the Makefile when appropriate
+
+If the repository reasonably supports Make but has no Makefile, create one when:
+- introducing or standardizing developer workflows,
+- adding CI validation that should also be runnable locally,
+- or the human requests workflow normalization.
+
+If a Makefile exists, extend it instead of creating duplicate shell scripts or
+duplicating raw commands in CI.
+
+### 4. Standard target vocabulary
+
+Use these standard target names when they apply:
+
+#### Core targets
+- `help` — list available commands
+- `setup` or `install` — first-time setup / dependency installation
+- `dev` — start local development mode
+- `build` — produce build artifacts
+- `test` — run the primary automated test suite
+- `lint` — run linting
+- `format` — apply formatting
+- `check` — fast validation without full build where applicable
+- `clean` — remove generated artifacts
+
+#### Common optional targets
+- `e2e` — end-to-end tests
+- `package` — package artifacts
+- `docs` — generate documentation
+- `update` — update dependencies or generated assets
+- `release` — perform release workflow
+- `plan` — planning/dry-run workflow (common in infra repos)
+- `deploy` — deployment workflow
+
+Use the conventional name unless there is a strong project-specific reason not
+to.
+
+### 5. Help target required
+
+The Makefile SHOULD include a `help` target or equivalent self-documenting
+mechanism so humans and AI agents can discover the available workflow.
+
+A good `help` target:
+- lists common targets,
+- provides a one-line description for each,
+- exposes the intended public command surface.
+
+### 6. Keep business logic centralized
+
+Do not duplicate the same workflow logic across:
+- CI YAML,
+- README examples,
+- AI instructions,
+- shell scripts,
+- and Make targets.
+
+Prefer:
+- Makefile as orchestration layer,
+- scripts for reusable internals when needed,
+- CI calling the Makefile,
+- docs referencing the Makefile.
+
+### 7. Keep target intent stable
+
+Once a standard target exists, do not silently change its meaning in a way that
+will surprise developers, CI, or AI agents.
+
+For example:
+- `make test` should remain the primary automated test command
+- `make lint` should remain the primary lint command
+- `make build` should remain the primary build command
+
+If behavior must change significantly, document it clearly.
+
+## Makefile Quality Standards
+
+When creating or modifying a Makefile:
+
+### Include `.PHONY` where appropriate
+Declare phony targets explicitly.
+
+### Keep names predictable
+Prefer short, conventional names over clever names.
+
+### Keep targets composable
+Let targets call other targets where helpful.
+
+### Keep output readable
+Commands should be understandable from logs in local runs and CI.
+
+### Avoid unnecessary duplication
+If multiple targets share logic, factor it cleanly.
+
+### Preserve project-specific detail
+The exact implementation may vary by stack. The standard governs the command
+surface, not the internal tool choice.
+
+## CI Requirements
+
+When CI performs an operation that has a corresponding Make target, CI MUST call
+the Make target instead of duplicating the raw underlying command.
+
+Examples:
+- test job uses `make test`
+- lint job uses `make lint`
+- build job uses `make build`
+- validation job uses `make check`
+
+This ensures local and CI workflows stay aligned.
+
+If CI cannot use the Make target, document the reason in the workflow or PR.
+
+## AI Agent Requirements
+
+AI agents MUST treat the repository's canonical command surface as the first
+place to look for project workflows. When a `Makefile` exists and is canonical,
+it is the first place to look.
+
+When analyzing a repository, identify:
+- whether a Makefile exists,
+- what public targets it exposes,
+- whether CI uses them,
+- whether README/docs use them,
+- and whether command drift exists.
+
+Before the first implementation step for a feature, the AI agent MUST record the
+command-surface discovery in the codebase analysis, PRD, task file, or session
+state. At minimum, identify:
+- whether a Makefile exists,
+- which public targets map to test, lint, build, dev, and check workflows,
+- and whether any required workflow lacks a target.
+
+When executing work:
+- prefer Make targets for setup, validation, testing, linting, formatting,
+  building, packaging, and release operations,
+- update the Makefile when adding a new standard workflow,
+- and avoid introducing direct raw commands into docs or CI when a Make target
+  should exist.
+
+## Validation
+
+A repository satisfies this rule when all of the following are true:
+
+1. A Makefile exists if the project reasonably supports Make.
+2. The Makefile exposes the applicable common workflows.
+3. Local docs prefer the Make targets.
+4. CI uses the same Make targets for equivalent operations when they exist.
+5. AI execution uses the Make targets instead of bypassing them unnecessarily.
+
+## Examples
+
+### Good pattern
+- `make dev`
+- `make test`
+- `make lint`
+- `make build`
+- CI invokes those same targets
+- README documents those same targets
+
+### Bad pattern
+- CI runs raw commands that differ from local workflows
+- README documents commands not exposed by the Makefile
+- AI calls raw tooling directly despite existing Make targets
+- build/test/lint behavior is duplicated in several places and drifts over time

--- a/rules/08-tdd-enforcement.md
+++ b/rules/08-tdd-enforcement.md
@@ -1,0 +1,137 @@
+# TDD Enforcement (Optional)
+
+> **This rule is optional.** It is only active when listed in the "Optional Rules
+> (enabled)" section of your project's `AGENTS.md`. Teams that do not practice
+> TDD or work on projects without test infrastructure should skip this rule.
+
+## Purpose
+
+Rule [04-validation-first.md](04-validation-first.md) requires writing validation
+steps before implementation. This rule goes further: when validation includes
+automated tests, it requires **evidence of red-then-green TDD** — proving that
+tests failed before implementation and passed after.
+
+Without this evidence, there is no way to distinguish "test written before code"
+from "test written to match existing code." The latter is not TDD and does not
+provide the same safety guarantees.
+
+## The TDD Evidence Requirement
+
+When a task involves writing automated tests, the validation results MUST include
+both phases:
+
+### Red Phase (before implementation)
+
+Run the test suite AFTER writing tests but BEFORE writing implementation code.
+Capture the output showing failures:
+
+```markdown
+**Red phase:**
+$ npm test -- users.test.ts
+
+FAIL  src/api/users.test.ts
+  ✕ returns 422 when email is invalid (3ms)
+  ✕ returns 422 when name is empty (1ms)
+  ✕ returns 200 with valid input (2ms)
+
+Tests: 3 failed, 3 total
+```
+
+### Green Phase (after implementation)
+
+Run the same test suite AFTER implementing the code. Capture the output showing
+all tests pass:
+
+```markdown
+**Green phase:**
+$ npm test -- users.test.ts
+
+PASS  src/api/users.test.ts
+  ✓ returns 422 when email is invalid (4ms)
+  ✓ returns 422 when name is empty (2ms)
+  ✓ returns 200 with valid input (8ms)
+
+Tests: 3 passed, 3 total
+```
+
+### Validation Results Table
+
+Include TDD evidence as a row in the standard validation results table:
+
+```markdown
+| # | Check                           | Result  | Notes              |
+|---|---------------------------------|---------|--------------------|
+| 1 | Tests fail before implementation | PASS   | 3/3 red            |
+| 2 | Tests pass after implementation  | PASS   | 3/3 green          |
+| 3 | No test modifications after red  | PASS   | Tests unchanged    |
+| 4 | TypeScript compiles              | PASS   |                    |
+| 5 | Lint passes                      | PASS   |                    |
+```
+
+## Rules
+
+### Tests must not be modified after the red phase
+Once a test is written and shown to fail, do not modify the test to make it pass.
+Only modify the implementation. If a test needs to change after seeing the red
+output, explain why:
+
+> "Modified test 2 after red phase: the original assertion used the wrong HTTP
+> status code (expected 400, should be 422 per the PRD). This is a spec
+> correction, not a test-to-match-code change."
+
+### Handle cases where red is not possible
+Sometimes tests cannot fail first:
+- **Existing functionality:** Tests for already-working behavior. Explain: "This
+  test validates existing behavior that was not previously tested."
+- **Configuration/setup tasks:** No meaningful test to write. Explain: "This task
+  is infrastructure setup with no testable behavior."
+- **No test runner:** Flag per [05-task-execution.md](05-task-execution.md):
+  "No test infrastructure. Manual validation only."
+
+In these cases, document WHY you could not show red-then-green. Silence is not
+acceptable — always explain.
+
+### Do not fake evidence
+If you wrote implementation before tests (even accidentally), do not delete the
+implementation to recreate a red phase. Instead, be honest:
+
+> "Implementation was written before tests for this task. Tests were added after
+> and pass, but TDD sequence was not followed. This is a deviation."
+
+Honesty enables the human to decide whether to accept or request a redo.
+
+## Optional: Automated TDD Check Script
+
+The `scripts/tdd-check.sh` script provides a lightweight automated check. It
+compares git commit timestamps to verify that test files were committed before
+or at the same time as implementation files.
+
+### Usage
+
+```bash
+# Check a single file pair
+./scripts/tdd-check.sh src/api/users.ts src/api/users.test.ts
+
+# Output (pass)
+# ✅ Test file was committed before or with implementation
+
+# Output (fail)
+# ⚠️  Implementation was committed before tests — TDD violation
+# Implementation: src/api/users.ts (committed 2025-03-10 14:30)
+# Test file:      src/api/users.test.ts (committed 2025-03-10 14:45)
+```
+
+### Limitations
+- Only checks commit timestamps, not edit order within a single commit
+- Requires git history (won't work before first commit)
+- Does not detect test modifications after red phase
+- This is a supplementary check, not a replacement for the evidence requirement
+
+### Integration
+Include the script output in the validation results table as an additional row:
+
+```markdown
+| # | Check                            | Result  | Notes             |
+|---|----------------------------------|---------|-------------------|
+| 6 | tdd-check.sh (timestamp verify)  | PASS    | test before impl  |
+```

--- a/rules/design/30-design-principles.md
+++ b/rules/design/30-design-principles.md
@@ -1,0 +1,56 @@
+# Design Principles
+
+## Purpose
+
+Define what makes user-facing work feel coherent, useful, and trustworthy.
+
+## Apply this when
+
+- designing new user-facing products or features
+- critiquing existing UX/UI
+- generating concepts, flows, or screen directions
+- building design systems or interaction patterns
+
+## Required outputs
+
+- explicit user and task understanding
+- flow and state awareness
+- rationale for where polish is concentrated
+
+## Rules
+
+1. **Orient the user quickly.** Every screen should answer where the user is,
+   what the system is showing, and what can be done next.
+2. **Optimize for confidence, not decoration.** A product feels premium when it
+   reduces uncertainty.
+3. **Spend polish where users notice risk and progress.** First touch, loading,
+   review, confirmation, success, and recovery deserve disproportionate care.
+4. **Separate browse mode from inspect mode.** Summary and detail should not
+   fight each other.
+5. **Design the full state model.** Loading, empty, partial, success, failure,
+   confirmation, and recovery states are part of the product.
+6. **Keep hierarchy legible.** One hero region per screen. Primary action should
+   be obvious.
+7. **Use visual intensity intentionally.** Strong gradients, saturation, and
+   motion should mean something.
+8. **Earn trust before destructive action.** Review before delete. Explain scope
+   and consequence.
+
+## Anti-patterns
+
+- hero-only design with no edge states
+- every card screaming for attention
+- destructive actions hidden behind vague labels
+- ornamental UI that obscures system status
+
+## Review questions
+
+- what should the user understand in the first three seconds
+- where does the screen spend its visual energy
+- what happens when things go wrong
+- what makes the user trust the interface
+
+## Example
+
+A system utility should not only look clean. It should make the user feel safe
+while taking actions that might affect persistent data.

--- a/rules/design/31-ux-brief-and-intent.md
+++ b/rules/design/31-ux-brief-and-intent.md
@@ -1,0 +1,52 @@
+# UX Brief and Intent
+
+## Purpose
+
+Establish the user, problem, emotional goal, and success criteria before screen
+work begins.
+
+## Apply this when
+
+- starting any meaningful UX/UI effort
+- reviewing whether a requested design direction is grounded
+- converting inspiration into project-specific design work
+
+## Required outputs
+
+- completed UX brief
+- primary user definition
+- job to be done
+- emotional goal
+- key flows
+- success criteria
+- known constraints and risks
+
+## Rules
+
+1. Name the user. "Everyone" is not a user.
+2. Define the job to be done in plain language.
+3. State the emotional goal explicitly.
+4. Capture the smallest useful set of flows before designing screens.
+5. List constraints early: platform, trust, permissions, data visibility,
+   compliance, latency, responsiveness, and brand expectations.
+6. Record known risks and unknowns instead of silently designing around them.
+
+## Anti-patterns
+
+- starting from visual style without problem framing
+- confusing brand mood with UX intent
+- vague goals like "make it modern"
+- omitting emotional risk in high-consequence flows
+
+## Review questions
+
+- who is this for
+- what job are they actually hiring the product to do
+- how should they feel during and after use
+- what would make this fail even if it looks good
+
+## Example
+
+Instead of: "Design a sleek dashboard."
+Use: "Design a dashboard that helps operators identify urgent failures in under
+10 seconds without creating false alarm fatigue."

--- a/rules/design/32-information-architecture.md
+++ b/rules/design/32-information-architecture.md
@@ -1,0 +1,50 @@
+# Information Architecture
+
+## Purpose
+
+Organize navigation, grouping, and labeling so the product remains understandable
+as complexity grows.
+
+## Apply this when
+
+- defining navigation
+- grouping content or tools
+- naming sections and actions
+- deciding what is visible now versus later
+
+## Required outputs
+
+- navigation model
+- content grouping rationale
+- labeling decisions
+- progressive disclosure strategy
+
+## Rules
+
+1. Group by user mental model, not by internal implementation.
+2. Keep top-level navigation shallow unless depth is necessary.
+3. Use progressive disclosure for advanced detail.
+4. Label actions and sections with concrete nouns and verbs.
+5. Avoid modal stacks and navigational dead ends.
+6. Summary views should support scanning; detail views should support confident
+   inspection and action.
+7. Revisit IA when a screen starts carrying too many unrelated jobs.
+
+## Anti-patterns
+
+- internal terminology exposed as UX labels
+- deep nested menus for common tasks
+- putting summary and forensic detail on the same plane
+- adding new top-level nav items for every feature
+
+## Review questions
+
+- can a first-time user predict where something lives
+- do names match what users would search for
+- what belongs in summary versus detail
+- what is hidden and why
+
+## Example
+
+"Review Cleanup" is usually better than "Optimization Artifacts" even if the
+latter is technically precise.

--- a/rules/design/33-user-journeys-and-state-inventory.md
+++ b/rules/design/33-user-journeys-and-state-inventory.md
@@ -1,0 +1,56 @@
+# User Journeys and State Inventory
+
+## Purpose
+
+Force the product to be designed as a working journey with explicit states,
+rather than as disconnected happy-path screens.
+
+## Apply this when
+
+- defining flows
+- reviewing product completeness
+- designing multi-step or system-driven experiences
+- critiquing an existing utility, dashboard, or workflow product
+
+## Required outputs
+
+- journey map for key flows
+- state inventory for each major screen or flow
+- recovery paths for failures and interruptions
+
+## Rules
+
+1. Map the key journey before polishing the screens.
+2. Enumerate at least these states where applicable:
+   - entry
+   - loading
+   - empty
+   - partial
+   - success
+   - failure
+   - destructive / confirmation
+   - recovery
+3. Distinguish between system-driven states and user-driven states.
+4. Ensure every failure state has a next step.
+5. Design for interrupted flows, not only clean runs.
+6. Preserve context between summary and detail views.
+
+## Anti-patterns
+
+- designing only the default state
+- spinner with no progress context
+- error messages with no recovery path
+- context loss when moving between screens
+
+## Review questions
+
+- what happens before this screen
+- what happens after it
+- what if the system is slow, empty, partial, or wrong
+- how does the user recover from interruption or failure
+
+## Example
+
+A scan results screen is incomplete unless it also defines the states for first
+run, in-progress, partial results, no findings, failed scan, and post-action
+success.

--- a/rules/design/34-trust-feedback-and-confirmation.md
+++ b/rules/design/34-trust-feedback-and-confirmation.md
@@ -1,0 +1,50 @@
+# Trust, Feedback, and Confirmation
+
+## Purpose
+
+Make system status visible, reduce anxiety, and prevent accidental harmful
+actions.
+
+## Apply this when
+
+- designing any loading, scanning, syncing, deleting, publishing, or payment flow
+- designing AI-assisted recommendations or summaries
+- designing actions that change persistent state
+
+## Required outputs
+
+- progress model
+- confirmation policy
+- rollback or recovery note
+- success and error states
+
+## Rules
+
+1. Show what the system is doing when work takes noticeable time.
+2. Prefer named progress over anonymous spinners.
+3. Use confirmation in proportion to risk.
+4. Prefer undo for low-risk reversible actions.
+5. For irreversible or high-consequence actions, communicate scope,
+   consequence, and affected objects clearly.
+6. Label AI-generated recommendations where user trust depends on it.
+7. Success states should confirm what changed, not merely that something is done.
+8. Error states should explain what the user can do next.
+
+## Anti-patterns
+
+- spinner without context
+- vague copy like "continue" on dangerous actions
+- warnings that feel dramatic but say nothing actionable
+- error states that dead-end the flow
+
+## Review questions
+
+- does the user know what is happening right now
+- does the user know what will happen next
+- is the confirmation proportional to the risk
+- can the user recover from mistakes
+
+## Example
+
+Instead of: "Processing..."
+Use: "Scanning caches, downloads, and mail attachments..."

--- a/rules/design/35-visual-system-and-hierarchy.md
+++ b/rules/design/35-visual-system-and-hierarchy.md
@@ -1,0 +1,51 @@
+# Visual System and Hierarchy
+
+## Purpose
+
+Create visual coherence, emphasis, and readability so the interface communicates
+clearly before the user reads deeply.
+
+## Apply this when
+
+- defining a screen system or design language
+- critiquing hierarchy, density, or emphasis
+- translating product intent into visual structure
+
+## Required outputs
+
+- hierarchy rationale
+- color and emphasis semantics
+- spacing and density guidance
+- typography intent
+
+## Rules
+
+1. Give each screen one visual hero.
+2. Reserve the strongest contrast, size, and saturation for the most important
+   information or action.
+3. Use color semantically, not decoratively.
+4. Support scanning with grouping, whitespace, and repeated structure.
+5. Keep density appropriate to the task: roomy for orientation, tighter for
+   inspection.
+6. Use motion sparingly and with purpose.
+7. Ensure decorative surfaces do not obscure readability.
+8. When using cards, give them distinct jobs instead of making them generic bins.
+
+## Anti-patterns
+
+- multiple hero regions fighting for attention
+- gradients and glass effects reducing legibility
+- every badge using a different meaning every time
+- dense administrative content styled like marketing
+
+## Review questions
+
+- where does the eye go first
+- what is secondary
+- which colors carry actual meaning
+- does spacing reflect importance and task type
+
+## Example
+
+A summary screen may use a strong top region for system status, then calmer
+modular cards below for inspection and action.

--- a/rules/design/36-screen-review-and-critique.md
+++ b/rules/design/36-screen-review-and-critique.md
@@ -1,0 +1,51 @@
+# Screen Review and Critique
+
+## Purpose
+
+Turn design review into a structured evaluation instead of taste-based opinions.
+
+## Apply this when
+
+- reviewing proposed screens
+- critiquing an existing product
+- comparing competing concepts
+- deciding whether a screen is ready to build
+
+## Required outputs
+
+- written review
+- strengths
+- risks
+- recommended changes
+- explicit tradeoffs
+
+## Rules
+
+1. Evaluate the screen in context of the flow, not in isolation.
+2. Identify the primary user question the screen should answer immediately.
+3. Check whether the primary action is obvious.
+4. Verify that state, risk, and next step are legible.
+5. Distinguish between visual polish issues and structural UX issues.
+6. Convert observations into reusable lessons where possible.
+7. Name tradeoffs explicitly instead of pretending every improvement is free.
+
+## Anti-patterns
+
+- critique based only on personal taste
+- discussing color while ignoring broken flow logic
+- approving screens that lack state coverage
+- changing hierarchy without considering the journey
+
+## Review questions
+
+- what question does this screen answer
+- what action does it want the user to take
+- what competes with that action
+- what happens if the state is empty, failed, or partial
+- what would confuse a first-time user
+
+## Example
+
+"The hierarchy is attractive" is weak.
+"The status region clearly anchors the user, but the destructive action is too
+close to passive review controls" is useful.

--- a/rules/design/37-accessibility-and-legibility.md
+++ b/rules/design/37-accessibility-and-legibility.md
@@ -1,0 +1,48 @@
+# Accessibility and Legibility
+
+## Purpose
+
+Ensure the interface remains readable, operable, and understandable across a
+range of users, devices, and conditions.
+
+## Apply this when
+
+- designing any screen, component, or flow
+- reviewing typography, contrast, motion, or target sizing
+- translating visual direction into build-ready requirements
+
+## Required outputs
+
+- accessibility notes
+- legibility checks
+- interaction considerations beyond ideal conditions
+
+## Rules
+
+1. Meet contrast needs for text and critical controls.
+2. Do not rely on color alone to convey meaning.
+3. Ensure touch and click targets are comfortably usable.
+4. Make keyboard flow and focus order coherent.
+5. Use motion to support comprehension, not to create distraction.
+6. Keep copy plain where the user is under stress or making decisions.
+7. Preserve readability when content grows, localizes, or wraps.
+8. Assume at least some users are tired, rushed, or unfamiliar.
+
+## Anti-patterns
+
+- faint gray text on decorative backgrounds
+- tiny icon-only controls with no support text
+- important status communicated only by color
+- error copy that hides the actual next step
+
+## Review questions
+
+- can this be understood quickly under less-than-ideal conditions
+- what fails if color disappears
+- what fails if the user tabs instead of clicks
+- does the wording reduce or increase cognitive load
+
+## Example
+
+A beautiful muted palette is not a success if users cannot distinguish warnings,
+primary actions, or disabled controls.

--- a/rules/design/38-design-memory-and-consistency.md
+++ b/rules/design/38-design-memory-and-consistency.md
@@ -1,0 +1,48 @@
+# Design Memory and Consistency
+
+## Purpose
+
+Preserve recurring patterns and decisions so the product feels like one system
+instead of a pile of individually attractive screens.
+
+## Apply this when
+
+- extending an existing product
+- creating a design system or component library
+- reviewing drift across screens or releases
+- handing work between humans and AI sessions
+
+## Required outputs
+
+- reusable pattern notes
+- decision log for important design choices
+- consistency checks across sibling screens
+
+## Rules
+
+1. Reuse established patterns unless there is a clear reason to change them.
+2. Record deviations intentionally instead of letting them accumulate.
+3. Keep labels, placement, and state behavior consistent across sibling screens.
+4. Preserve semantic color meaning over time.
+5. Store design rationale, not only final screenshots.
+6. When a new pattern is introduced, define where else it should or should not appear.
+7. Prefer a small number of reliable patterns over many clever one-offs.
+
+## Anti-patterns
+
+- every flow inventing its own confirmation pattern
+- similar cards with different interaction behavior
+- changing visual meaning of colors across screens
+- losing earlier decisions between sessions and re-debating them from scratch
+
+## Review questions
+
+- what existing pattern should this match
+- what decision needs to be remembered later
+- where is the product teaching users one behavior and then breaking that lesson
+- is this a new pattern or an accidental inconsistency
+
+## Example
+
+If detail drawers open from the right everywhere else, a modal-on-click in one
+screen should be treated as a deliberate exception or corrected.

--- a/scripts/tdd-check.sh
+++ b/scripts/tdd-check.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# tdd-check.sh — Verify TDD ordering by comparing git commit timestamps
+#
+# Checks that a test file was committed before or at the same time as its
+# corresponding implementation file. This is a supplementary check — it does
+# not replace the red-then-green evidence requirement in rules/08-tdd-enforcement.md.
+#
+# Usage:
+#   ./scripts/tdd-check.sh <implementation-file> <test-file>
+#
+# Examples:
+#   ./scripts/tdd-check.sh src/api/users.ts src/api/users.test.ts
+#   ./scripts/tdd-check.sh lib/utils.py tests/test_utils.py
+#
+# Exit codes:
+#   0 — TDD order confirmed (test committed before or with implementation)
+#   1 — TDD violation detected (implementation committed before tests)
+#   2 — Usage error or missing files
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+usage() {
+  echo "Usage: $0 <implementation-file> <test-file>"
+  echo ""
+  echo "Compares git commit timestamps to verify TDD ordering."
+  echo "The test file should be committed before or with the implementation file."
+  exit 2
+}
+
+# Validate arguments
+if [[ $# -ne 2 ]]; then
+  usage
+fi
+
+IMPL_FILE="$1"
+TEST_FILE="$2"
+
+# Check we're in a git repo
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+  echo -e "${RED}Error: Not inside a git repository${NC}"
+  exit 2
+fi
+
+# Check files exist in git history
+if ! git log -1 --format="%at" -- "$IMPL_FILE" &>/dev/null || \
+   [[ -z "$(git log -1 --format="%at" -- "$IMPL_FILE" 2>/dev/null)" ]]; then
+  echo -e "${YELLOW}Warning: $IMPL_FILE has no git history (not yet committed)${NC}"
+  echo "Cannot verify TDD ordering until both files are committed."
+  exit 2
+fi
+
+if ! git log -1 --format="%at" -- "$TEST_FILE" &>/dev/null || \
+   [[ -z "$(git log -1 --format="%at" -- "$TEST_FILE" 2>/dev/null)" ]]; then
+  echo -e "${YELLOW}Warning: $TEST_FILE has no git history (not yet committed)${NC}"
+  echo "Cannot verify TDD ordering until both files are committed."
+  exit 2
+fi
+
+# Get the timestamp of the first commit touching each file
+IMPL_FIRST_COMMIT=$(git log --diff-filter=A --format="%at" -- "$IMPL_FILE" | tail -1)
+TEST_FIRST_COMMIT=$(git log --diff-filter=A --format="%at" -- "$TEST_FILE" | tail -1)
+
+# Fallback: if --diff-filter=A returns nothing (file existed before history),
+# use the earliest commit that touched the file
+if [[ -z "$IMPL_FIRST_COMMIT" ]]; then
+  IMPL_FIRST_COMMIT=$(git log --format="%at" -- "$IMPL_FILE" | tail -1)
+fi
+
+if [[ -z "$TEST_FIRST_COMMIT" ]]; then
+  TEST_FIRST_COMMIT=$(git log --format="%at" -- "$TEST_FILE" | tail -1)
+fi
+
+# Format timestamps for human display
+IMPL_DATE=$(git log --diff-filter=A --format="%ai" -- "$IMPL_FILE" | tail -1)
+TEST_DATE=$(git log --diff-filter=A --format="%ai" -- "$TEST_FILE" | tail -1)
+
+if [[ -z "$IMPL_DATE" ]]; then
+  IMPL_DATE=$(git log --format="%ai" -- "$IMPL_FILE" | tail -1)
+fi
+
+if [[ -z "$TEST_DATE" ]]; then
+  TEST_DATE=$(git log --format="%ai" -- "$TEST_FILE" | tail -1)
+fi
+
+# Compare timestamps
+if [[ "$TEST_FIRST_COMMIT" -le "$IMPL_FIRST_COMMIT" ]]; then
+  echo -e "${GREEN}✅ Test file was committed before or with implementation${NC}"
+  echo "   Test file:      $TEST_FILE (first committed: $TEST_DATE)"
+  echo "   Implementation: $IMPL_FILE (first committed: $IMPL_DATE)"
+  exit 0
+else
+  echo -e "${RED}⚠️  Implementation was committed before tests — TDD violation${NC}"
+  echo "   Implementation: $IMPL_FILE (first committed: $IMPL_DATE)"
+  echo "   Test file:      $TEST_FILE (first committed: $TEST_DATE)"
+  exit 1
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# setup.sh — Generate platform-specific stub files that reference .ai-rules/.
+#
+# Intended to be run from inside a consumer project's .ai-rules/ subtree:
+#
+#   .ai-rules/setup.sh --platforms cursor,windsurf,copilot
+#   .ai-rules/setup.sh --platforms all
+#   .ai-rules/setup.sh --list
+#
+# Idempotency: if a stub already contains the reference marker it is left
+# untouched. If a file exists at the target path without the marker, the
+# stub is prepended — UNLESS the existing file starts with YAML frontmatter,
+# in which case the script warns and skips rather than corrupt the file.
+#
+# Platform definitions live in PLATFORMS_TABLE below; stub bodies live in
+# templates/platform-stubs/. To add or modify a platform, edit both.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+STUBS_DIR="$SCRIPT_DIR/templates/platform-stubs"
+AGENTS_MD="$SCRIPT_DIR/AGENTS.md"
+RULES_REL=".ai-rules"
+
+REFERENCE_MARKER="ai-rules-reference"
+
+# name|relative_path|template_filename|description
+# Keep in sync with templates/platform-stubs/ and README.md platform table.
+PLATFORMS_TABLE=(
+  "claude|CLAUDE.md|claude.md|Claude Code (root CLAUDE.md with @import)"
+  "cursor|.cursor/rules/ai-rules.mdc|cursor.mdc|Cursor (.cursor/rules/*.mdc with MDC frontmatter)"
+  "windsurf|.windsurf/rules/ai-rules.md|windsurf.md|Windsurf (.windsurf/rules/*.md with YAML frontmatter)"
+  "copilot|.github/copilot-instructions.md|copilot.md|GitHub Copilot (.github/copilot-instructions.md)"
+  "amp|AGENTS.md|amp.md|Amp (root AGENTS.md)"
+)
+
+COUNT_CREATE=0
+COUNT_UPDATE=0
+COUNT_SKIP=0
+COUNT_WARN=0
+
+usage() {
+  local exit_code="${1:-0}"
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Generate platform-specific config stubs that reference ${RULES_REL}/.
+
+Options:
+  --platforms <list>   Comma-separated platforms (see --list), or 'all'.
+  --list               List supported platforms and exit.
+  --dry-run            Show what would happen without writing files.
+  -h, --help           Show this help message.
+
+Examples:
+  $(basename "$0") --platforms cursor,windsurf
+  $(basename "$0") --platforms all
+  $(basename "$0") --list
+EOF
+  exit "$exit_code"
+}
+
+list_platforms() {
+  echo "Supported platforms:"
+  local row name desc
+  for row in "${PLATFORMS_TABLE[@]}"; do
+    IFS='|' read -r name _ _ desc <<< "$row"
+    printf "  %-10s - %s\n" "$name" "$desc"
+  done
+  exit 0
+}
+
+supported_names() {
+  local row name names=""
+  for row in "${PLATFORMS_TABLE[@]}"; do
+    IFS='|' read -r name _ _ _ <<< "$row"
+    names="${names:+$names,}$name"
+  done
+  echo "$names"
+}
+
+# Sets PL_PATH and PL_TEMPLATE for the requested platform. Returns 1 on miss.
+lookup_platform() {
+  local target="$1" row name path template _desc
+  for row in "${PLATFORMS_TABLE[@]}"; do
+    IFS='|' read -r name path template _desc <<< "$row"
+    if [[ "$name" == "$target" ]]; then
+      PL_PATH="$path"
+      PL_TEMPLATE="$template"
+      return 0
+    fi
+  done
+  return 1
+}
+
+DRY_RUN=false
+PLATFORMS=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --platforms)
+      if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
+        echo "Error: --platforms requires a value." >&2
+        usage 1
+      fi
+      PLATFORMS="$2"; shift 2 ;;
+    --list) list_platforms ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    -h|--help) usage 0 ;;
+    *) echo "Unknown option: $1" >&2; usage 1 ;;
+  esac
+done
+
+if [[ -z "$PLATFORMS" ]]; then
+  echo "Error: --platforms is required."
+  echo "Run with --list to see supported platforms, or --help for usage."
+  exit 1
+fi
+
+if [[ "$PLATFORMS" == "all" ]]; then
+  PLATFORMS="$(supported_names)"
+fi
+
+if [[ ! -f "$AGENTS_MD" ]]; then
+  echo "Warning: $AGENTS_MD not found." >&2
+  echo "         Stubs will reference ${RULES_REL}/AGENTS.md but the source is missing." >&2
+fi
+
+has_reference() {
+  local file="$1"
+  [[ -f "$file" ]] && grep -qF -- "$REFERENCE_MARKER" "$file"
+}
+
+has_frontmatter() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+  [[ "$(grep -v -- '^[[:space:]]*$' "$file" | head -n 1)" == "---" ]]
+}
+
+write_stub() {
+  local abs_path="$1" template_file="$2" platform="$3" rel_path="$4"
+
+  if [[ ! -f "$template_file" ]]; then
+    echo "  [warn]   template missing: $template_file — skipping $platform" >&2
+    COUNT_WARN=$((COUNT_WARN + 1))
+    return 0
+  fi
+
+  if has_reference "$abs_path"; then
+    echo "  [skip]   $rel_path — already has ai-rules reference"
+    COUNT_SKIP=$((COUNT_SKIP + 1))
+    return 0
+  fi
+
+  if [[ -f "$abs_path" ]] && has_frontmatter "$abs_path"; then
+    echo "  [warn]   $rel_path — existing file has YAML frontmatter; cannot safely prepend." >&2
+    echo "           Add '<!-- $REFERENCE_MARKER -->' manually after the frontmatter, or" >&2
+    echo "           remove the file to regenerate from the template." >&2
+    COUNT_WARN=$((COUNT_WARN + 1))
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == true ]]; then
+    if [[ -f "$abs_path" ]]; then
+      echo "  [dry-run] would update $rel_path ($platform)"
+      COUNT_UPDATE=$((COUNT_UPDATE + 1))
+    else
+      echo "  [dry-run] would create $rel_path ($platform)"
+      COUNT_CREATE=$((COUNT_CREATE + 1))
+    fi
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$abs_path")"
+
+  if [[ -f "$abs_path" ]]; then
+    local tmp
+    tmp="$(mktemp)"
+    { cat "$template_file"; printf '\n'; cat "$abs_path"; } > "$tmp"
+    # Use redirection (not mv) so $abs_path keeps its original inode, mode, and ACLs.
+    cat "$tmp" > "$abs_path"
+    rm -f "$tmp"
+    echo "  [update] $rel_path — prepended ai-rules reference"
+    COUNT_UPDATE=$((COUNT_UPDATE + 1))
+  else
+    cp "$template_file" "$abs_path"
+    echo "  [create] $rel_path"
+    COUNT_CREATE=$((COUNT_CREATE + 1))
+  fi
+}
+
+echo "Setting up ai-rules platform stubs..."
+echo ""
+
+IFS=',' read -ra PLATFORM_LIST <<< "$PLATFORMS"
+for platform in "${PLATFORM_LIST[@]}"; do
+  platform="$(echo "$platform" | tr -d '[:space:]')"
+  [[ -z "$platform" ]] && continue
+
+  if ! lookup_platform "$platform"; then
+    echo "Unknown platform: $platform (skipping)" >&2
+    echo "  Run with --list to see supported platforms." >&2
+    echo ""
+    COUNT_WARN=$((COUNT_WARN + 1))
+    continue
+  fi
+
+  echo "$platform:"
+  write_stub "$PROJECT_ROOT/$PL_PATH" "$STUBS_DIR/$PL_TEMPLATE" "$platform" "$PL_PATH"
+  echo ""
+done
+
+echo "Summary: $COUNT_CREATE created, $COUNT_UPDATE updated, $COUNT_SKIP skipped, $COUNT_WARN warnings."
+if [[ "$DRY_RUN" == true ]]; then
+  echo "(dry-run: no files were written)"
+else
+  echo "Done. Review the generated files and commit them to your project."
+fi

--- a/templates/design/design-review-checklist.md
+++ b/templates/design/design-review-checklist.md
@@ -1,0 +1,30 @@
+# Design Review Checklist
+
+## Orientation
+- Is it obvious where the user is?
+- Is it obvious what this screen is for?
+- Is the primary action clear?
+
+## Flow and State
+- Are loading, empty, success, and error states defined?
+- Are destructive and recovery states defined?
+- Does the screen fit coherently into the broader journey?
+
+## Trust
+- Does the UI communicate what will happen next?
+- Is risky behavior proportionately confirmed?
+- Are AI-generated recommendations labeled where needed?
+
+## Hierarchy
+- Is there one clear hero region?
+- What competes with the primary action?
+- Is the density appropriate for the task?
+
+## Accessibility
+- Is contrast sufficient?
+- Are targets large enough?
+- Is the interface understandable without relying only on color?
+
+## Consistency
+- Does this screen reuse established patterns?
+- Do labels, placements, and states behave like sibling screens?

--- a/templates/design/screen-spec-template.md
+++ b/templates/design/screen-spec-template.md
@@ -1,0 +1,40 @@
+# Screen Spec: <Screen Name>
+
+## Purpose
+
+<!-- What this screen is for. -->
+
+## Primary User Question
+
+<!-- What question this screen should answer immediately. -->
+
+## Primary Action
+
+<!-- Main intended action. -->
+
+## Secondary Actions
+
+-
+-
+
+## Content Hierarchy
+
+1.
+2.
+3.
+
+## States Covered
+
+- default
+- loading
+- empty
+- failure
+- success
+
+## Trust / Confirmation Notes
+
+<!-- What requires explanation, warning, confirmation, or undo. -->
+
+## Accessibility Notes
+
+<!-- Contrast, keyboard navigation, motion, screen reader, touch target notes. -->

--- a/templates/design/state-inventory-template.md
+++ b/templates/design/state-inventory-template.md
@@ -1,0 +1,28 @@
+# State Inventory: <Flow or Feature Name>
+
+## Entry States
+-
+
+## Loading States
+-
+
+## Empty States
+-
+
+## Partial States
+-
+
+## Success States
+-
+
+## Failure States
+-
+
+## Destructive / Confirmation States
+-
+
+## Recovery States
+-
+
+## Notes
+-

--- a/templates/design/ux-brief-template.md
+++ b/templates/design/ux-brief-template.md
@@ -1,0 +1,43 @@
+# UX Brief: <Project or Feature Name>
+
+## Summary
+
+<!-- One paragraph. What is being designed and why. -->
+
+## User
+
+<!-- Who this is for. Avoid "everyone." -->
+
+## Problem / Job to Be Done
+
+<!-- What job the user is trying to get done. -->
+
+## Emotional Goal
+
+<!-- How the user should feel when using the product. -->
+
+## Success Criteria
+
+- Criterion 1
+- Criterion 2
+- Criterion 3
+
+## Key Flows
+
+1. Flow 1
+2. Flow 2
+3. Flow 3
+
+## Constraints
+
+- Constraint 1
+- Constraint 2
+
+## Risks
+
+- Risk 1
+- Risk 2
+
+## Notes
+
+<!-- Dependencies, assumptions, brand constraints, platform expectations. -->

--- a/templates/design/visual-audit-template.md
+++ b/templates/design/visual-audit-template.md
@@ -1,0 +1,46 @@
+# Visual Audit: <Product / Screen Set>
+
+## What is being audited
+
+<!-- Product, screen group, flow, or component set. -->
+
+## What works well
+
+-
+-
+-
+
+## UX patterns worth reusing
+
+-
+-
+-
+
+## UI patterns worth reusing
+
+-
+-
+-
+
+## Risks / tradeoffs
+
+-
+-
+-
+
+## Lessons to apply elsewhere
+
+-
+-
+-
+
+## Copy / adapt / avoid
+
+### Copy
+-
+
+### Adapt
+-
+
+### Avoid
+-

--- a/templates/platform-stubs/amp.md
+++ b/templates/platform-stubs/amp.md
@@ -1,0 +1,7 @@
+<!-- ai-rules-reference -->
+# AI Development Rules
+
+Follow the AI development rules defined in `.ai-rules/AGENTS.md` and all
+referenced rule files in `.ai-rules/rules/` before beginning any feature work.
+
+<!-- Project-specific Amp instructions below this line -->

--- a/templates/platform-stubs/claude.md
+++ b/templates/platform-stubs/claude.md
@@ -1,0 +1,4 @@
+<!-- ai-rules-reference -->
+@.ai-rules/AGENTS.md
+
+<!-- Project-specific Claude Code instructions below this line -->

--- a/templates/platform-stubs/copilot.md
+++ b/templates/platform-stubs/copilot.md
@@ -1,0 +1,7 @@
+<!-- ai-rules-reference -->
+## AI Development Rules
+
+Follow the AI development rules defined in `.ai-rules/AGENTS.md` and all
+referenced rule files in `.ai-rules/rules/` before beginning any feature work.
+
+<!-- Project-specific Copilot instructions below this line -->

--- a/templates/platform-stubs/cursor.mdc
+++ b/templates/platform-stubs/cursor.mdc
@@ -1,0 +1,10 @@
+---
+description: Project AI development rules (see .ai-rules/AGENTS.md)
+alwaysApply: true
+---
+<!-- ai-rules-reference -->
+
+Follow the AI development rules defined in `.ai-rules/AGENTS.md` and all
+referenced rule files in `.ai-rules/rules/` before beginning any feature work.
+
+<!-- Project-specific Cursor rules below this line -->

--- a/templates/platform-stubs/windsurf.md
+++ b/templates/platform-stubs/windsurf.md
@@ -1,0 +1,10 @@
+---
+trigger: always_on
+description: Project AI development rules (see .ai-rules/AGENTS.md)
+---
+<!-- ai-rules-reference -->
+
+Follow the AI development rules defined in `.ai-rules/AGENTS.md` and all
+referenced rule files in `.ai-rules/rules/` before beginning any feature work.
+
+<!-- Project-specific Windsurf rules below this line -->

--- a/templates/prd.md
+++ b/templates/prd.md
@@ -1,0 +1,79 @@
+# PRD: <Feature Name>
+
+## Summary
+
+<!-- One paragraph. What is being built and why. -->
+
+## Codebase Analysis
+
+<!-- Produced during Step 2 of the PRD process. Must be reviewed and confirmed
+by the human before the PRD is finalized. -->
+
+### Explored
+
+<!-- List files and directories you actually read, with one-line summaries. -->
+
+- `path/to/file.ext` — What you found
+
+### Relevant Patterns
+
+<!-- Existing conventions, architecture patterns, naming conventions. -->
+
+- Pattern 1
+- Pattern 2
+
+### Constraints Discovered
+
+<!-- Missing tooling, complexity, shared ownership, performance limits. -->
+
+- Constraint 1
+- Constraint 2
+
+### Assumptions (need human confirmation)
+
+<!-- Judgment calls you made. The human must confirm or correct these. -->
+
+- Assumption 1
+- Assumption 2
+
+## Background
+
+<!-- What exists today. What is wrong or missing. Build on the codebase analysis
+above with narrative context. Cite file paths. -->
+
+## Goals
+
+<!-- Bulleted list of what this feature achieves. Each goal should be
+measurable or observable. -->
+
+- Goal 1
+- Goal 2
+- Goal 3
+
+## Non-Goals
+
+<!-- Explicitly out-of-scope items to prevent scope creep. -->
+
+- Non-goal 1
+- Non-goal 2
+
+## Architecture & Approach
+
+<!-- How this fits into the existing codebase. Include:
+- Files to be modified (with rationale)
+- New files to be created (with purpose)
+- External dependencies or services involved
+- Data flow or state changes -->
+
+## Acceptance Criteria
+
+<!-- Each criterion must be verifiable (yes/no), specific (concrete values),
+and testable (you can describe a test for it). -->
+
+- [ ] AC-1:
+- [ ] AC-2:
+- [ ] AC-3:
+
+## Open Questions
+
+<!-- Anything unresolved that could affect implementation. -->

--- a/templates/project-plan.md
+++ b/templates/project-plan.md
@@ -1,0 +1,89 @@
+# Project Plan: <Project Name>
+
+> Generated from project brief discussion on <date>.
+
+## Project Brief
+
+### Vision
+
+<!-- One paragraph. What we are building and why. -->
+
+### Success Metrics
+
+<!-- Project-level metrics. How we know the whole initiative succeeded. -->
+
+- Metric 1
+- Metric 2
+
+### Constraints
+
+<!-- Timeline, technology, team, compliance, backward compatibility, etc. -->
+
+- Constraint 1
+- Constraint 2
+
+### Known Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+|      |        |            |            |
+
+## Dependency Map
+
+<!-- Show cross-feature and cross-phase dependencies.
+Feature A (Phase 1) ──→ Feature C (Phase 2)  [reason]
+-->
+
+## Phases
+
+### Phase 1: <Phase Name>
+
+**Objective:** <!-- What is true when this phase is complete. -->
+
+**Entry Criteria:**
+- Project kickoff complete
+
+**Exit Criteria:**
+<!-- Observable conditions that prove this phase is done. -->
+- Exit criterion 1
+- Exit criterion 2
+
+**Features:**
+- Feature A: <one-line description> → [PRD](phase-1/prd-feature-a.md)
+- Feature B: <one-line description> → [PRD](phase-1/prd-feature-b.md)
+
+---
+
+### Phase 2: <Phase Name>
+
+**Objective:**
+
+**Entry Criteria:**
+- Phase 1 exit criteria met
+
+**Exit Criteria:**
+- Exit criterion 1
+- Exit criterion 2
+
+**Features:**
+- Feature C: <one-line description> → [PRD](phase-2/prd-feature-c.md)
+- Feature D: <one-line description> → [PRD](phase-2/prd-feature-d.md)
+
+---
+
+<!-- Repeat for additional phases -->
+
+## Phase Completion Tracking
+
+| Phase | Status | Exit Criteria Met | Notes |
+|-------|--------|-------------------|-------|
+| Phase 1 | Not started | 0/2 | |
+| Phase 2 | Not started | 0/2 | |
+
+## Discovered Issues & Scope Changes
+
+<!-- Log issues discovered during implementation that affect the project plan. -->
+
+| # | Issue | Discovered In | Impact | Resolution |
+|---|-------|---------------|--------|------------|
+|   |       |               |        |            |

--- a/templates/session-state.md
+++ b/templates/session-state.md
@@ -1,0 +1,30 @@
+## Session State: <feature-name>
+Last updated: <YYYY-MM-DDTHH:MM:SSZ>
+
+### Current Position
+- **Working on:** Task X.Y — <task description>
+- **Status:** <specific state>
+- **Blocked:** No
+
+### Key Decisions
+
+<!-- Decisions confirmed by the human. Do not remove or change these. -->
+
+- <Decision> — confirmed by human
+
+### Codebase Understanding
+
+<!-- What you learned beyond the initial PRD codebase analysis. -->
+
+- `path/to/file.ts` — <what you learned>
+
+### What's Next
+
+1. <Next immediate action>
+2. <Action after that>
+
+### Blockers / Open Questions
+
+<!-- Anything unresolved. Remove this section if none. -->
+
+- None

--- a/templates/tasks.md
+++ b/templates/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: <Feature Name>
+
+> Generated from [PRD: <Feature Name>](prd-<feature-name>.md)
+
+## Acceptance Criteria Traceability
+
+| AC   | Criterion (short description) | Tasks |
+|------|-------------------------------|-------|
+| AC-1 |                               |       |
+| AC-2 |                               |       |
+| AC-3 |                               |       |
+
+## Relevant Files
+
+<!-- Identified by READING the codebase, not guessing. -->
+
+- `path/to/file.ext` — Description of relevance
+- `path/to/file.test.ext` — Tests for the above
+
+### Notes
+
+- Test files live alongside the source files they test.
+- Run tests with: `[project-specific test command]`
+
+## Tasks
+
+- [ ] 1.0 <Parent Task Title>                           <!-- Serves: AC-X -->
+  - [ ] 1.1 [Sub-task description]
+  - [ ] 1.2 [Sub-task description]
+  - **Validates when:**
+    - <observable outcome>
+    - <test command with expected result>
+
+- [ ] 2.0 <Parent Task Title>                           <!-- Serves: AC-X, AC-Y -->
+  - [ ] 2.1 [Sub-task description]
+  - [ ] 2.2 [Sub-task description]
+  - **Validates when:**
+    - <observable outcome>
+    - <specific input> -> <expected output>
+
+<!-- Repeat for each parent task -->
+
+## Current Status
+
+<!-- Updated in real-time as tasks are completed. Remove this section
+header and replace with actual status when work begins. -->
+
+Not started.


### PR DESCRIPTION
## Summary
- Vendor [JonathanPorta/ai-rules](https://github.com/JonathanPorta/ai-rules) at tag **v0.5.0** into `.ai-rules/` via `git subtree --squash`.
- Generate platform stubs for **Claude Code** (`CLAUDE.md`) and **GitHub Copilot** (`.github/copilot-instructions.md`) so both agents pick up the shared rule set from `.ai-rules/AGENTS.md`.

## Test plan
- [ ] Confirm `.ai-rules/` is present and pinned to `v0.5.0` (see `.ai-rules/.version`).
- [ ] Open the repo in Claude Code and verify `CLAUDE.md` resolves the `@.ai-rules/AGENTS.md` import.
- [ ] Verify Copilot loads `.github/copilot-instructions.md`.